### PR TITLE
Ordering examples

### DIFF
--- a/Nucoro Application API.postman_collection.json
+++ b/Nucoro Application API.postman_collection.json
@@ -1819,6 +1819,277 @@
 							],
 							"cookie": [],
 							"body": "{\n    \"count\": 1,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"7c537c90-026f-4619-9205-a91e47cfff87\",\n            \"name\": \"3M\",\n            \"isin\": \"US88579Y1010\",\n            \"ticker\": \"MMM\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XNYS\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {\n                \"fees\": [\n                    {\n                        \"amount\": \"0\",\n                        \"operation\": \"+\",\n                        \"lower_limit\": \"\",\n                        \"upper_limit\": \"\"\n                    },\n                    {\n                        \"amount\": \"0\",\n                        \"operation\": \"*\",\n                        \"lower_limit\": \"\",\n                        \"upper_limit\": \"\"\n                    }\n                ],\n                \"taxes\": {\n                    \"buy\": [\n                        {\n                            \"amount\": \"0\",\n                            \"operation\": \"*\",\n                            \"lower_limit\": \"\",\n                            \"upper_limit\": \"\"\n                        },\n                        {\n                            \"amount\": \"0\",\n                            \"operation\": \"+\",\n                            \"lower_limit\": \"\",\n                            \"upper_limit\": \"\"\n                        }\n                    ],\n                    \"sell\": [\n                        {\n                            \"amount\": \"0.0000051\",\n                            \"operation\": \"*\",\n                            \"lower_limit\": \"0\",\n                            \"upper_limit\": \"1000000\"\n                        },\n                        {\n                            \"amount\": \"5.1\",\n                            \"operation\": \"+\",\n                            \"lower_limit\": \"1000000\",\n                            \"upper_limit\": \"\"\n                        }\n                    ]\n                },\n                \"corp_act\": {},\n                \"kiid_url\": \"\",\n                \"forex_fees\": {\n                    \"amount\": \"0.001\",\n                    \"operation\": \"*\"\n                },\n                \"pival_code\": \"03523538003\",\n                \"broker_code\": \"01024\",\n                \"issuance_ccy\": \"USD\",\n                \"asset_market_currency\": \"USD\"\n            },\n            \"categories\": [\n                {\n                    \"uuid\": \"96e17d77-d821-464c-aa2c-16e0db0a02ef\",\n                    \"name\": \"US traded stocks\",\n                    \"code\": \"US_TRADED_STOCKS\",\n                    \"order\": 14,\n                    \"type\": \"collections\"\n                },\n                {\n                    \"uuid\": \"add87b60-4480-48f9-b13e-18d092bcc19e\",\n                    \"name\": \"Industrials\",\n                    \"code\": \"INDUSTRIALS\",\n                    \"order\": 1,\n                    \"type\": \"industry\"\n                },\n                {\n                    \"uuid\": \"1f26c038-bfe7-4079-9078-9838e4b1c935\",\n                    \"name\": \"Industrial Products\",\n                    \"code\": \"INDUSTRIAL_PRODUCTS\",\n                    \"order\": 2,\n                    \"type\": \"sector\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        }\n    ]\n}"
+						},
+						{
+							"name": "ok, ordering by name",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{auth_token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{host}}:{{port}}/api/v2/assets/?ordering=-name",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"api",
+										"v2",
+										"assets",
+										""
+									],
+									"query": [
+										{
+											"key": "ordering",
+											"value": "-name"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Date",
+									"value": "Tue, 08 Mar 2022 08:34:18 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Content-Length",
+									"value": "47116"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Server",
+									"value": "nginx"
+								},
+								{
+									"key": "Vary",
+									"value": "Accept, Origin, Accept-Language, Cookie"
+								},
+								{
+									"key": "Allow",
+									"value": "GET, HEAD, OPTIONS"
+								},
+								{
+									"key": "X-Frame-Options",
+									"value": "DENY"
+								},
+								{
+									"key": "Content-Language",
+									"value": "en-gb"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "Referrer-Policy",
+									"value": "same-origin"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=31536000; includeSubDomains"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"count\": 82,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"407e69dd-2723-4f11-bafa-7f90b46f6838\",\n            \"name\": \"Xtrackers STOXX Europe 600 Health Care Swap UCITS ETF 1C\",\n            \"isin\": \"LU0292103222\",\n            \"ticker\": \"DXSE\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"e445fc75-da5e-4fb5-a33c-0f081b7a16c2\",\n                    \"name\": \"Healthcare\",\n                    \"code\": \"HEALTHCARE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"d5694e8a-d222-4f05-954f-bace0a42976b\",\n            \"name\": \"Xtrackers II Eurozone Government Bond UCITS ETF 1C\",\n            \"isin\": \"LU0290355717\",\n            \"ticker\": \"DBXN\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"337ac1dd-df71-4d4d-880d-b5330487a67b\",\n                    \"name\": \"Bonds\",\n                    \"code\": \"FIXED_INCOME\",\n                    \"order\": 1,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"9ef7fcea-e045-4bc5-a4ef-d404776dbd98\",\n                    \"name\": \"Government Bonds\",\n                    \"code\": \"GOVERNMENT_BONDS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"8e35d4e1-43e4-4517-9e97-b3404e3260b9\",\n            \"name\": \"Xtrackers Future Mobility UCITS ETF 1C\",\n            \"isin\": \"IE00BGV5VR99\",\n            \"ticker\": \"XMOV\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"bca90596-4fbd-43a5-ae0d-34f30707bf03\",\n                    \"name\": \"Clean energy\",\n                    \"code\": \"CLEAN_ENERGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"629fb93c-f992-4128-9cb4-84a85e39faf9\",\n            \"name\": \"Xtrackers Euro Stoxx 50 UCITS ETF 1C\",\n            \"isin\": \"LU0380865021\",\n            \"ticker\": \"DXET\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"6fa4b3ae-fa4d-4ab8-966e-af59c700daf4\",\n                    \"name\": \"Stocks Europe\",\n                    \"code\": \"STOCKS_EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"89f083a5-c503-4862-99c0-c60f30a253cd\",\n            \"name\": \"Xtrackers DAX UCITS ETF 1C\",\n            \"isin\": \"LU0274211480\",\n            \"ticker\": \"DBXD\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"6fa4b3ae-fa4d-4ab8-966e-af59c700daf4\",\n                    \"name\": \"Stocks Europe\",\n                    \"code\": \"STOCKS_EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"e22f9e28-da3d-4a1c-ae4e-282c4dd9b632\",\n            \"name\": \"Vonovia SE\",\n            \"isin\": \"DE000A1ML7J1\",\n            \"ticker\": \"VNA\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"418d2769-4de8-46d6-916e-e1f2cee671f8\",\n                    \"name\": \"Real Estate\",\n                    \"code\": \"REAL_ESTATE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"62641ea0-d91c-443c-b240-aac43a7aa40e\",\n            \"name\": \"Volkswagen AG\",\n            \"isin\": \"DE0007664005\",\n            \"ticker\": \"VOW\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"0afc59ee-1d16-4162-a459-61ca53eaae04\",\n                    \"name\": \"Technology\",\n                    \"code\": \"TECHNOLOGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"9b5f24f3-f4ab-4900-9aed-d4801550ec80\",\n            \"name\": \"UBS ETF (IE) Global Gender Equality UCITS ETF\",\n            \"isin\": \"IE00BDR5H073\",\n            \"ticker\": \"GGUE\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"8454e62b-0d04-4cf5-a99d-a31c9910cfe6\",\n                    \"name\": \"Diversity\",\n                    \"code\": \"DIVERSITY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"7ca4684a-aab3-4686-ad22-7f9f08d1914c\",\n            \"name\": \"SPDR MSCI Europe Health Care UCITS ETF\",\n            \"isin\": \"IE00BKWQ0H23\",\n            \"ticker\": \"SPYH\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"e445fc75-da5e-4fb5-a33c-0f081b7a16c2\",\n                    \"name\": \"Healthcare\",\n                    \"code\": \"HEALTHCARE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"d13d89ce-5326-4672-bc35-6acffee85f61\",\n            \"name\": \"SPDR Bloomberg Barclays 0-3 Year Euro Corporate Bond UCITS ETF\",\n            \"isin\": \"IE00BC7GZW19\",\n            \"ticker\": \"SYBD\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"337ac1dd-df71-4d4d-880d-b5330487a67b\",\n                    \"name\": \"Bonds\",\n                    \"code\": \"FIXED_INCOME\",\n                    \"order\": 1,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"0f775947-7c29-4397-a9fe-d2796bb8aec1\",\n                    \"name\": \"Corporate Bonds\",\n                    \"code\": \"CORPORATE_BONDS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"d99716a0-19c2-41c3-8337-7c4b0d589bc5\",\n            \"name\": \"Solar Energy UCITS\",\n            \"isin\": \"IE00BMFNWC33\",\n            \"ticker\": \"TANN\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"bca90596-4fbd-43a5-ae0d-34f30707bf03\",\n                    \"name\": \"Clean energy\",\n                    \"code\": \"CLEAN_ENERGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"46f49f7c-fabb-4b2f-92bb-934e9d13453f\",\n            \"name\": \"Siemens AG\",\n            \"isin\": \"DE0007236101\",\n            \"ticker\": \"SIE\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"0afc59ee-1d16-4162-a459-61ca53eaae04\",\n                    \"name\": \"Technology\",\n                    \"code\": \"TECHNOLOGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"3df1b146-acb3-4d52-bfb8-f35b6f30ca7b\",\n            \"name\": \"Sap SE\",\n            \"isin\": \"DE0007164600\",\n            \"ticker\": \"SAP\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"0afc59ee-1d16-4162-a459-61ca53eaae04\",\n                    \"name\": \"Technology\",\n                    \"code\": \"TECHNOLOGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"5f58b036-858c-42b1-af46-e025179d0198\",\n            \"name\": \"Muenchener Rueckversicherungs-Gesellschaft AG\",\n            \"isin\": \"DE0008430026\",\n            \"ticker\": \"MUV2\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"3d9a591a-98e7-4c98-942c-4c3a3ae17396\",\n                    \"name\": \"Financials\",\n                    \"code\": \"FINANCIALS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"d3148a65-c384-4c7c-8172-b95f29141b28\",\n            \"name\": \"Lyxor World Water (DR) UCITS ETF\",\n            \"isin\": \"FR0010527275\",\n            \"ticker\": \"LYM8\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"e6378236-7e8d-409b-8c6a-fd7912d6b11e\",\n                    \"name\": \"Water\",\n                    \"code\": \"WATER\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"6d0e1a8d-09c6-4816-96c4-84753053e978\",\n            \"name\": \"Lyxor STOXX Europe 600 Healthcare UCITS ETF\",\n            \"isin\": \"LU1834986900\",\n            \"ticker\": \"LHTC\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"e445fc75-da5e-4fb5-a33c-0f081b7a16c2\",\n                    \"name\": \"Healthcare\",\n                    \"code\": \"HEALTHCARE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"ade887dd-9894-417e-9cfa-ad08d377e9fb\",\n            \"name\": \"Lyxor S&P 500 UCITS ETF - Dist (EUR)\",\n            \"isin\": \"LU0496786574\",\n            \"ticker\": \"LYPS\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"2612dfca-d742-4695-b0ee-668a973b0590\",\n                    \"name\": \"United States\",\n                    \"code\": \"UNITED_STATES\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"0607e811-9e75-45c1-98e0-707eac259726\",\n                    \"name\": \"Stocks USA\",\n                    \"code\": \"STOCKS_USA\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"cedd4d71-f894-4238-a038-1fc4ce08d3c1\",\n            \"name\": \"Lyxor New Energy (DR) UCITS ETF\",\n            \"isin\": \"FR0010524777\",\n            \"ticker\": \"LYM9\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"bca90596-4fbd-43a5-ae0d-34f30707bf03\",\n                    \"name\": \"Clean energy\",\n                    \"code\": \"CLEAN_ENERGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"9e875b14-5719-4aa0-b30e-8cbb9a554ab7\",\n            \"name\": \"Lyxor MSCI World UCITS ETF - Dist\",\n            \"isin\": \"FR0010315770\",\n            \"ticker\": \"LYYA\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"fc19f01a-67ea-408e-ac50-78b483d1a63d\",\n                    \"name\": \"Global\",\n                    \"code\": \"GLOBAL\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"c5de6934-1de9-4814-9bb7-4d7411733e9d\",\n                    \"name\": \"Stocks Global\",\n                    \"code\": \"STOCKS_GLOBAL\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"2e2f6a0c-4f3e-4dc3-9991-58a3a7f3c459\",\n            \"name\": \"Lyxor MSCI Millennials ESG Filtered (DR) UCITS ETF\",\n            \"isin\": \"LU2023678449\",\n            \"ticker\": \"GENY\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"8454e62b-0d04-4cf5-a99d-a31c9910cfe6\",\n                    \"name\": \"Diversity\",\n                    \"code\": \"DIVERSITY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"a4a198ac-5608-4352-a23f-ea64eaa375d8\",\n            \"name\": \"Lyxor MSCI Future Mobility ESG Filtered (DR) UCITS ETF\",\n            \"isin\": \"LU2023679090\",\n            \"ticker\": \"ELCR\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"bca90596-4fbd-43a5-ae0d-34f30707bf03\",\n                    \"name\": \"Clean energy\",\n                    \"code\": \"CLEAN_ENERGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"ba7fd98e-917b-4d33-a41c-c4fd18771192\",\n            \"name\": \"Lyxor Global Gender Equality (DR) UCITS ETF\",\n            \"isin\": \"LU1691909508\",\n            \"ticker\": \"VOOM\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"8454e62b-0d04-4cf5-a99d-a31c9910cfe6\",\n                    \"name\": \"Diversity\",\n                    \"code\": \"DIVERSITY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"4c374634-3517-4722-97ef-c75df51a483a\",\n            \"name\": \"Lyxor EURO STOXX 50 (DR) UCITS ETF - Dist\",\n            \"isin\": \"FR0007054358\",\n            \"ticker\": \"LYSX\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"6fa4b3ae-fa4d-4ab8-966e-af59c700daf4\",\n                    \"name\": \"Stocks Europe\",\n                    \"code\": \"STOCKS_EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"092a997a-ddbf-4dd5-ae0b-e7101ef4bb6b\",\n            \"name\": \"Lyxor Commodities Thomson Reuters/CoreCommodity\",\n            \"isin\": \"FR0010358887\",\n            \"ticker\": \"CRNL.L\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"e33356ff-5edf-49cc-9945-d0a4204218ce\",\n                    \"name\": \"Alternatives\",\n                    \"code\": \"ALTERNATIVE\",\n                    \"order\": 3,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"fc19f01a-67ea-408e-ac50-78b483d1a63d\",\n                    \"name\": \"Global\",\n                    \"code\": \"GLOBAL\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"2e5b2e66-9380-4e32-9f73-bdf229e552c9\",\n                    \"name\": \"Commodities\",\n                    \"code\": \"COMMODITIES\",\n                    \"order\": 1,\n                    \"type\": \"ASSET_CLASS\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"c74dfdc7-a1fe-4ec5-9c67-429e66b5d60c\",\n            \"name\": \"Lyxor BofAML EUR High Yield Ex-Financial Bond UCITS ETF\",\n            \"isin\": \"LU1812090543\",\n            \"ticker\": \"LYQY\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"337ac1dd-df71-4d4d-880d-b5330487a67b\",\n                    \"name\": \"Bonds\",\n                    \"code\": \"FIXED_INCOME\",\n                    \"order\": 1,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"f1112ad2-7117-40af-84d4-c0f5038e18a8\",\n                    \"name\": \"SRI\",\n                    \"code\": \"SRI\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"c080379d-7856-4e51-b92f-d48b6f154f22\",\n            \"name\": \"L&G Clean Water UCITS ETF\",\n            \"isin\": \"IE00BK5BC891\",\n            \"ticker\": \"XMLC\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"e6378236-7e8d-409b-8c6a-fd7912d6b11e\",\n                    \"name\": \"Water\",\n                    \"code\": \"WATER\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"6ae5dbf4-0cdb-49f1-8920-56671f87d8c5\",\n            \"name\": \"L&G Clean Energy UCITS\",\n            \"isin\": \"IE00BK5BCH80\",\n            \"ticker\": \"RENW\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"bca90596-4fbd-43a5-ae0d-34f30707bf03\",\n                    \"name\": \"Clean energy\",\n                    \"code\": \"CLEAN_ENERGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"ea363640-ca7f-4b28-a683-616cd7613ddd\",\n            \"name\": \"iShares Thomson Reuters Inclusion and Diversity UCITS ETF\",\n            \"isin\": \"IE00BD0B9B76\",\n            \"ticker\": \"OPEN\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"8454e62b-0d04-4cf5-a99d-a31c9910cfe6\",\n                    \"name\": \"Diversity\",\n                    \"code\": \"DIVERSITY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"32ba7874-3da3-4fa0-a77d-f2fada7db41a\",\n            \"name\": \"iShares STOXX Europe 600 UCITS ETF (DE)\",\n            \"isin\": \"DE0002635307\",\n            \"ticker\": \"EXSA\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"6fa4b3ae-fa4d-4ab8-966e-af59c700daf4\",\n                    \"name\": \"Stocks Europe\",\n                    \"code\": \"STOCKS_EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"be3efa3a-af6d-482c-b8b3-b41c80039fbe\",\n            \"name\": \"iShares STOXX Europe 600 Health Care UCITS ETF\",\n            \"isin\": \"DE000A0Q4R36\",\n            \"ticker\": \"EXV4\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"e445fc75-da5e-4fb5-a33c-0f081b7a16c2\",\n                    \"name\": \"Healthcare\",\n                    \"code\": \"HEALTHCARE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"34f37f73-83c2-432d-9992-1b936cf7cdf3\",\n            \"name\": \"iShares S&P 500 EUR Hedged UCITS ETF (Acc)\",\n            \"isin\": \"IE00B3ZW0K18\",\n            \"ticker\": \"IBCF\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"6fa4b3ae-fa4d-4ab8-966e-af59c700daf4\",\n                    \"name\": \"Stocks Europe\",\n                    \"code\": \"STOCKS_EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"b7fccdaa-4180-4cc2-9fb0-0a48436289db\",\n            \"name\": \"iShares MSCI Europe Health Care Sector UCITS\",\n            \"isin\": \"IE00BMW42181\",\n            \"ticker\": \"ESIH\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"e445fc75-da5e-4fb5-a33c-0f081b7a16c2\",\n                    \"name\": \"Healthcare\",\n                    \"code\": \"HEALTHCARE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"feb7d229-1b59-457a-8099-ed9d14da5f2c\",\n            \"name\": \"iShares J.P. Morgan USD EM Bond EUR Hedged UCITS ETF (Dist)\",\n            \"isin\": \"IE00B9M6RS56\",\n            \"ticker\": \"IS3C\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"337ac1dd-df71-4d4d-880d-b5330487a67b\",\n                    \"name\": \"Bonds\",\n                    \"code\": \"FIXED_INCOME\",\n                    \"order\": 1,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"0f775947-7c29-4397-a9fe-d2796bb8aec1\",\n                    \"name\": \"Corporate Bonds\",\n                    \"code\": \"CORPORATE_BONDS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"c6260f8a-aba4-4435-9061-045934c00529\",\n            \"name\": \"iShares Gold ETF\",\n            \"isin\": \"DE0104136236\",\n            \"ticker\": \"CSGOLD\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"e33356ff-5edf-49cc-9945-d0a4204218ce\",\n                    \"name\": \"Alternatives\",\n                    \"code\": \"ALTERNATIVE\",\n                    \"order\": 3,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"e296aea1-19aa-4f71-8b2a-7ac3761aea21\",\n                    \"name\": \"Gold\",\n                    \"code\": \"GOLD\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"fc19f01a-67ea-408e-ac50-78b483d1a63d\",\n                    \"name\": \"Global\",\n                    \"code\": \"GLOBAL\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"0c05e72b-06ff-415b-96a5-1197d632c245\",\n            \"name\": \"iShares Global Water UCITS ETF\",\n            \"isin\": \"IE00B1TXK627\",\n            \"ticker\": \"IQQQ\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"e6378236-7e8d-409b-8c6a-fd7912d6b11e\",\n                    \"name\": \"Water\",\n                    \"code\": \"WATER\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"81d8f3f6-6e1a-4dd6-8667-70762dc4e58a\",\n            \"name\": \"iShares Global Clean Energy UCITS ETF\",\n            \"isin\": \"IE00B1XNHC34\",\n            \"ticker\": \"IQQH\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"bca90596-4fbd-43a5-ae0d-34f30707bf03\",\n                    \"name\": \"Clean energy\",\n                    \"code\": \"CLEAN_ENERGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"d3128dec-f6de-4177-8aa0-5d0dc5be5e32\",\n            \"name\": \"iShares EUR Ultrashort Bond UCITS ETF EUR (Dist)\",\n            \"isin\": \"IE00BCRY6557\",\n            \"ticker\": \"IS3M\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"337ac1dd-df71-4d4d-880d-b5330487a67b\",\n                    \"name\": \"Bonds\",\n                    \"code\": \"FIXED_INCOME\",\n                    \"order\": 1,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"e3b07067-1586-47d9-a46c-db79524b1873\",\n                    \"name\": \"Short Term Bonds\",\n                    \"code\": \"SHORT_TERM_BONDS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"b55ee618-1517-48ae-b859-c79403932621\",\n            \"name\": \"iShares EUR Govt Bond 3-5yr UCITS ETF EUR (Dist)\",\n            \"isin\": \"IE00B1FZS681\",\n            \"ticker\": \"IBCN\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"337ac1dd-df71-4d4d-880d-b5330487a67b\",\n                    \"name\": \"Bonds\",\n                    \"code\": \"FIXED_INCOME\",\n                    \"order\": 1,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"9ef7fcea-e045-4bc5-a4ef-d404776dbd98\",\n                    \"name\": \"Government Bonds\",\n                    \"code\": \"GOVERNMENT_BONDS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"b216b9ee-594d-4094-8078-77b9b12f542a\",\n                    \"name\": \"Switzerland\",\n                    \"code\": \"SWITZERLAND\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"b7f72b8b-307d-430c-9b97-f795ba38a061\",\n            \"name\": \"iShares EUR Corp Bond Large Cap UCITS ETF EUR (Dist)\",\n            \"isin\": \"IE0032523478\",\n            \"ticker\": \"IBCS\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"337ac1dd-df71-4d4d-880d-b5330487a67b\",\n                    \"name\": \"Bonds\",\n                    \"code\": \"FIXED_INCOME\",\n                    \"order\": 1,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"0f775947-7c29-4397-a9fe-d2796bb8aec1\",\n                    \"name\": \"Corporate Bonds\",\n                    \"code\": \"CORPORATE_BONDS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"60b77fef-5011-4f92-b258-586ca2d650c8\",\n            \"name\": \"iShares EUR Corp Bond 1-5yr UCITS ETF EUR (Dist)\",\n            \"isin\": \"IE00B4L60045\",\n            \"ticker\": \"EUNT\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"337ac1dd-df71-4d4d-880d-b5330487a67b\",\n                    \"name\": \"Bonds\",\n                    \"code\": \"FIXED_INCOME\",\n                    \"order\": 1,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"0f775947-7c29-4397-a9fe-d2796bb8aec1\",\n                    \"name\": \"Corporate Bonds\",\n                    \"code\": \"CORPORATE_BONDS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"e52b1f4d-1851-4787-ab4a-dd699924f34e\",\n            \"name\": \"iShares EUR Corp Bond 0-3yr ESG UCITS ETF\",\n            \"isin\": \"IE00BYZTVV78\",\n            \"ticker\": \"QDVL\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"337ac1dd-df71-4d4d-880d-b5330487a67b\",\n                    \"name\": \"Bonds\",\n                    \"code\": \"FIXED_INCOME\",\n                    \"order\": 1,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"f1112ad2-7117-40af-84d4-c0f5038e18a8\",\n                    \"name\": \"SRI\",\n                    \"code\": \"SRI\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"dc49064a-99e4-4a97-aecb-25abe77725de\",\n            \"name\": \"iShares Electric Vehicles and Driving Technology UCITS ETF\",\n            \"isin\": \"IE00BGL86Z12\",\n            \"ticker\": \"IEVD\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"bca90596-4fbd-43a5-ae0d-34f30707bf03\",\n                    \"name\": \"Clean energy\",\n                    \"code\": \"CLEAN_ENERGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"99801469-1b6c-4121-a47f-09990c34806c\",\n            \"name\": \"iShares Core MSCI Europe UCITS ETF EUR (Dist)\",\n            \"isin\": \"IE00B1YZSC51\",\n            \"ticker\": \"IQQY\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"6fa4b3ae-fa4d-4ab8-966e-af59c700daf4\",\n                    \"name\": \"Stocks Europe\",\n                    \"code\": \"STOCKS_EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"7994fbb2-8772-4825-85ae-f70c98631c5d\",\n            \"name\": \"iShares Core EURO STOXX 50 UCITS ETF EUR (Dist)\",\n            \"isin\": \"IE0008471009\",\n            \"ticker\": \"EUN2\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"6fa4b3ae-fa4d-4ab8-966e-af59c700daf4\",\n                    \"name\": \"Stocks Europe\",\n                    \"code\": \"STOCKS_EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"b1945b47-84ad-4eca-b064-e6f4573cb033\",\n            \"name\": \"iShares Core EURO STOXX 50 UCITS ETF EUR (Acc)\",\n            \"isin\": \"IE00B53L3W79\",\n            \"ticker\": \"SXRT\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"6fa4b3ae-fa4d-4ab8-966e-af59c700daf4\",\n                    \"name\": \"Stocks Europe\",\n                    \"code\": \"STOCKS_EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"b28ef8e4-cecc-4d24-b436-308abe18717d\",\n            \"name\": \"iShares Core EURO STOXX 50 UCITS ETF (DE)\",\n            \"isin\": \"DE0005933956\",\n            \"ticker\": \"EXW1\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"6fa4b3ae-fa4d-4ab8-966e-af59c700daf4\",\n                    \"name\": \"Stocks Europe\",\n                    \"code\": \"STOCKS_EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"6d0950a7-b4fb-4e9b-a764-f9fdaaadfe4a\",\n            \"name\": \"iShares Core EUR Govt Bond UCITS ETF EUR (Dist)\",\n            \"isin\": \"IE00B4WXJJ64\",\n            \"ticker\": \"EUNH\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"337ac1dd-df71-4d4d-880d-b5330487a67b\",\n                    \"name\": \"Bonds\",\n                    \"code\": \"FIXED_INCOME\",\n                    \"order\": 1,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"9ef7fcea-e045-4bc5-a4ef-d404776dbd98\",\n                    \"name\": \"Government Bonds\",\n                    \"code\": \"GOVERNMENT_BONDS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"00e9826e-f977-4c4b-b4ef-c8dcf478239a\",\n            \"name\": \"iShares Core EUR Corp Bond UCITS ETF EUR (Dist)\",\n            \"isin\": \"IE00B3F81R35\",\n            \"ticker\": \"EUN5\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"337ac1dd-df71-4d4d-880d-b5330487a67b\",\n                    \"name\": \"Bonds\",\n                    \"code\": \"FIXED_INCOME\",\n                    \"order\": 1,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"0f775947-7c29-4397-a9fe-d2796bb8aec1\",\n                    \"name\": \"Corporate Bonds\",\n                    \"code\": \"CORPORATE_BONDS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"1b92fb09-9507-417e-a00e-79d5c3435dde\",\n            \"name\": \"iShares Core DAX UCITS ETF (DE)\",\n            \"isin\": \"DE0005933931\",\n            \"ticker\": \"EXS1\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"6fa4b3ae-fa4d-4ab8-966e-af59c700daf4\",\n                    \"name\": \"Stocks Europe\",\n                    \"code\": \"STOCKS_EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"41d4c7fa-a1f1-4bf7-9022-e387dfa8ee40\",\n            \"name\": \"iShares Asia Property Yield\",\n            \"isin\": \"IE00B1FZS244\",\n            \"ticker\": \"IASP.L\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"e33356ff-5edf-49cc-9945-d0a4204218ce\",\n                    \"name\": \"Alternatives\",\n                    \"code\": \"ALTERNATIVE\",\n                    \"order\": 3,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"277e5127-7d7c-4e02-9985-e9fa116a1588\",\n                    \"name\": \"Asia\",\n                    \"code\": \"ASIA_PACIFIC\",\n                    \"order\": 40,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"418d2769-4de8-46d6-916e-e1f2cee671f8\",\n                    \"name\": \"Real Estate\",\n                    \"code\": \"REAL_ESTATE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"5d87f232-a46b-4365-9009-b7ad486c2007\",\n            \"name\": \"iShares Ageing Population UCITS ETF\",\n            \"isin\": \"IE00BYZK4669\",\n            \"ticker\": \"2B77\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"8454e62b-0d04-4cf5-a99d-a31c9910cfe6\",\n                    \"name\": \"Diversity\",\n                    \"code\": \"DIVERSITY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"523678e8-f48d-4486-927c-094df8e6f895\",\n            \"name\": \"Invesco STOXX Europe 600 Optimised Health Care UCITS ETF Acc\",\n            \"isin\": \"IE00B5MJYY16\",\n            \"ticker\": \"SC0T\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"e445fc75-da5e-4fb5-a33c-0f081b7a16c2\",\n                    \"name\": \"Healthcare\",\n                    \"code\": \"HEALTHCARE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"2b9661c7-bd0c-48e6-948c-8015deeb73df\",\n            \"name\": \"Invesco Solar Energy UCITS\",\n            \"isin\": \"IE00BM8QRZ79\",\n            \"ticker\": \"S0LR\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"bca90596-4fbd-43a5-ae0d-34f30707bf03\",\n                    \"name\": \"Clean energy\",\n                    \"code\": \"CLEAN_ENERGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"e8eb6505-3edf-4206-bfd1-d648f52c3cef\",\n            \"name\": \"Invesco Global Clean Energy UCITS\",\n            \"isin\": \"IE00BLRB0242\",\n            \"ticker\": \"G1CE\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"bca90596-4fbd-43a5-ae0d-34f30707bf03\",\n                    \"name\": \"Clean energy\",\n                    \"code\": \"CLEAN_ENERGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"7aa682cd-f8c9-408f-975c-9b6af2cd71d6\",\n            \"name\": \"Infineon Technologies AG\",\n            \"isin\": \"DE0006231004\",\n            \"ticker\": \"IFX\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"0afc59ee-1d16-4162-a459-61ca53eaae04\",\n                    \"name\": \"Technology\",\n                    \"code\": \"TECHNOLOGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"76c60663-b333-4a72-aea5-92dd1ab68406\",\n            \"name\": \"iClima Distributed Renewable Energy UCITS\",\n            \"isin\": \"IE00BLCH4S17\",\n            \"ticker\": \"DGEN\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"bca90596-4fbd-43a5-ae0d-34f30707bf03\",\n                    \"name\": \"Clean energy\",\n                    \"code\": \"CLEAN_ENERGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"8d92677b-13a0-444b-a0b7-972c3ab6d6c7\",\n            \"name\": \"Henkel AG\",\n            \"isin\": \"DE0006048408\",\n            \"ticker\": \"HEN\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"1223958a-04d7-49f1-8908-63a31180170b\",\n                    \"name\": \"Consumer Goods\",\n                    \"code\": \"CONSUMER_GOODS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"8b4af9aa-b38f-432d-8cbc-591e286ebbb3\",\n            \"name\": \"HANetf S&P Global Clean Energy Select HANzero\",\n            \"isin\": \"IE00BLH3CQ86\",\n            \"ticker\": \"ZER0\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"bca90596-4fbd-43a5-ae0d-34f30707bf03\",\n                    \"name\": \"Clean energy\",\n                    \"code\": \"CLEAN_ENERGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"4ab1b698-4840-42be-a2d9-d9a3b006081e\",\n            \"name\": \"Fresenius Medical Care AG\",\n            \"isin\": \"DE0005785802\",\n            \"ticker\": \"FME\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"e445fc75-da5e-4fb5-a33c-0f081b7a16c2\",\n                    \"name\": \"Healthcare\",\n                    \"code\": \"HEALTHCARE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"de2fb47e-0041-45aa-9f1d-27979fadc6c6\",\n            \"name\": \"First Trust Nasdaq Clean Edge Green Energy UCITS\",\n            \"isin\": \"IE00BDBRT036\",\n            \"ticker\": \"QCLN\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"bca90596-4fbd-43a5-ae0d-34f30707bf03\",\n                    \"name\": \"Clean energy\",\n                    \"code\": \"CLEAN_ENERGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"6ae02c6f-8cc9-4ee5-be86-511f088e878f\",\n            \"name\": \"E.On SE\",\n            \"isin\": \"DE000ENAG999\",\n            \"ticker\": \"EOAN\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"23a37673-f476-4d6f-8801-d9e254dbd1e1\",\n                    \"name\": \"Energy\",\n                    \"code\": \"ENERGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"f296f05f-74f7-424d-9a5a-ec5b883b4ef8\",\n            \"name\": \"Deutsche Telekom AG\",\n            \"isin\": \"DE0005557508\",\n            \"ticker\": \"DTE\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"0afc59ee-1d16-4162-a459-61ca53eaae04\",\n                    \"name\": \"Technology\",\n                    \"code\": \"TECHNOLOGY\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"6a0cf5a3-5071-4354-87cc-2ce84c0da238\",\n            \"name\": \"Deutsche Post AG\",\n            \"isin\": \"DE0005552004\",\n            \"ticker\": \"DPW\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"9c08c3ce-5f36-4f3a-8f51-e64b7fc2ab6d\",\n                    \"name\": \"Logistics\",\n                    \"code\": \"LOGISTICS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"734afe74-f351-4e73-a8ef-d1ba7e11d517\",\n            \"name\": \"Deutsche Boerse\",\n            \"isin\": \"DE0005810055\",\n            \"ticker\": \"DB1\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"3d9a591a-98e7-4c98-942c-4c3a3ae17396\",\n                    \"name\": \"Financials\",\n                    \"code\": \"FINANCIALS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"1e8cf2ad-b52c-4c6b-bb96-d1c257614b6d\",\n            \"name\": \"Deka MSCI World Climate Change ESG UCITS ETF\",\n            \"isin\": \"DE000ETFL581\",\n            \"ticker\": \"D6RP\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"815b58d9-22d0-47ea-9120-788b69ff3497\",\n                    \"name\": \"Climate change\",\n                    \"code\": \"CLIMATE_CHANGE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"2439cd12-f1f2-4a18-8ef5-4ee3e13f45f6\",\n            \"name\": \"Deka MSCI USA Climate Change ESG UCITS ETF\",\n            \"isin\": \"DE000ETFL573\",\n            \"ticker\": \"D6RQ\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"815b58d9-22d0-47ea-9120-788b69ff3497\",\n                    \"name\": \"Climate change\",\n                    \"code\": \"CLIMATE_CHANGE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"e180eb09-83ac-467d-9132-f0518f910d9e\",\n            \"name\": \"Deka MSCI Japan Climate Change ESG UCITS ETF\",\n            \"isin\": \"DE000ETFL318\",\n            \"ticker\": \"EL45\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"815b58d9-22d0-47ea-9120-788b69ff3497\",\n                    \"name\": \"Climate change\",\n                    \"code\": \"CLIMATE_CHANGE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"59a946c4-1857-48e2-acf2-600501d671d7\",\n            \"name\": \"Deka MSCI Germany Climate Change ESG UCITS ETF\",\n            \"isin\": \"DE000ETFL540\",\n            \"ticker\": \"D6RT\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"815b58d9-22d0-47ea-9120-788b69ff3497\",\n                    \"name\": \"Climate change\",\n                    \"code\": \"CLIMATE_CHANGE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"f808e63f-c10f-4e24-82c2-980db41cd7c7\",\n            \"name\": \"Deka MSCI Europe Climate Change ESG UCITS ETF\",\n            \"isin\": \"DE000ETFL565\",\n            \"ticker\": \"D6RR\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"815b58d9-22d0-47ea-9120-788b69ff3497\",\n                    \"name\": \"Climate change\",\n                    \"code\": \"CLIMATE_CHANGE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"0b6ece6b-a218-4817-a93a-d43556bb39fa\",\n            \"name\": \"Deka MSCI EMU Climate Change ESG UCITS ETF\",\n            \"isin\": \"DE000ETFL557\",\n            \"ticker\": \"D6RS\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"815b58d9-22d0-47ea-9120-788b69ff3497\",\n                    \"name\": \"Climate change\",\n                    \"code\": \"CLIMATE_CHANGE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"cc73ed51-e251-4791-92c8-9c0d5463036b\",\n            \"name\": \"Daimler AG\",\n            \"isin\": \"DE0007100000\",\n            \"ticker\": \"DAI\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"1223958a-04d7-49f1-8908-63a31180170b\",\n                    \"name\": \"Consumer Goods\",\n                    \"code\": \"CONSUMER_GOODS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"3a253f51-ccc3-418f-8493-6970b39586fb\",\n            \"name\": \"Continental AG\",\n            \"isin\": \"DE0005439004\",\n            \"ticker\": \"CON\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"1223958a-04d7-49f1-8908-63a31180170b\",\n                    \"name\": \"Consumer Goods\",\n                    \"code\": \"CONSUMER_GOODS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"a61c496a-7c0d-4e0b-b173-88941cb16e46\",\n            \"name\": \"BNP Paribas Easy EUR High Yield SRI Fossil Free UCITS\",\n            \"isin\": \"LU2244386137\",\n            \"ticker\": \"ASRG\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"337ac1dd-df71-4d4d-880d-b5330487a67b\",\n                    \"name\": \"Bonds\",\n                    \"code\": \"FIXED_INCOME\",\n                    \"order\": 1,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"f1112ad2-7117-40af-84d4-c0f5038e18a8\",\n                    \"name\": \"SRI\",\n                    \"code\": \"SRI\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"ad8227e3-3062-4865-817d-ab60dcd841e3\",\n            \"name\": \"Beiersdorf AG\",\n            \"isin\": \"DE0005200000\",\n            \"ticker\": \"BEI\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"1223958a-04d7-49f1-8908-63a31180170b\",\n                    \"name\": \"Consumer Goods\",\n                    \"code\": \"CONSUMER_GOODS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"fbb68cea-ad01-47ad-981e-4b38414d3604\",\n            \"name\": \"Bayerische Motoren Werke AG\",\n            \"isin\": \"DE0005190003\",\n            \"ticker\": \"BMW\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"1223958a-04d7-49f1-8908-63a31180170b\",\n                    \"name\": \"Consumer Goods\",\n                    \"code\": \"CONSUMER_GOODS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"eae3ca0e-9c76-4d57-bc6d-7c03ea6fa85c\",\n            \"name\": \"Bayer AG\",\n            \"isin\": \"DE000BAY0017\",\n            \"ticker\": \"BAYN\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"e445fc75-da5e-4fb5-a33c-0f081b7a16c2\",\n                    \"name\": \"Healthcare\",\n                    \"code\": \"HEALTHCARE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"5b0d6fc6-5177-4a16-a9c3-c775c38f04e2\",\n            \"name\": \"Basf SE\",\n            \"isin\": \"DE000BASF111\",\n            \"ticker\": \"BAS\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"3841a9d5-4a31-4ace-b375-073d80b06cd8\",\n                    \"name\": \"Manufacturing\",\n                    \"code\": \"MANUFACTURING\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"052c726b-77ad-484f-b179-09e7d7d70f5d\",\n            \"name\": \"Amundi MSCI Europe UCITS ETF - EUR (C)\",\n            \"isin\": \"LU1681042609\",\n            \"ticker\": \"CEUG\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"6fa4b3ae-fa4d-4ab8-966e-af59c700daf4\",\n                    \"name\": \"Stocks Europe\",\n                    \"code\": \"STOCKS_EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"bf05ce29-2de0-4530-bf84-4ca4405769d0\",\n            \"name\": \"Amundi EURO STOXX 50 UCITS ETF DR - EUR (C)\",\n            \"isin\": \"LU1681047236\",\n            \"ticker\": \"V50A\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                },\n                {\n                    \"uuid\": \"6fa4b3ae-fa4d-4ab8-966e-af59c700daf4\",\n                    \"name\": \"Stocks Europe\",\n                    \"code\": \"STOCKS_EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"3943bfd0-9fb9-4f22-b9f1-a34890d5101d\",\n            \"name\": \"Amundi ETF MSCI Europe Healthcare UCITS ETF\",\n            \"isin\": \"FR0010688192\",\n            \"ticker\": \"18M6\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"e445fc75-da5e-4fb5-a33c-0f081b7a16c2\",\n                    \"name\": \"Healthcare\",\n                    \"code\": \"HEALTHCARE\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2e068ff0-f5c2-4110-8657-f1cfdd3cb782\",\n                    \"name\": \"Europe\",\n                    \"code\": \"EUROPE\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"ETF\"\n        },\n        {\n            \"uuid\": \"30d2316f-c50e-4199-a694-2d4049407a6a\",\n            \"name\": \"Allianz SE\",\n            \"isin\": \"DE0008404005\",\n            \"ticker\": \"ALV\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"3d9a591a-98e7-4c98-942c-4c3a3ae17396\",\n                    \"name\": \"Financials\",\n                    \"code\": \"FINANCIALS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"556f2c03-6b57-4f63-93be-50db4e494be3\",\n                    \"name\": \"Germany\",\n                    \"code\": \"GERMANY\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        },\n        {\n            \"uuid\": \"dd0b1b50-885f-4ca0-8fdb-75a5e291c7ce\",\n            \"name\": \"Adidas AG\",\n            \"isin\": \"DE000A1EWWW0\",\n            \"ticker\": \"ADS\",\n            \"status\": \"ACTIVE\",\n            \"market\": \"XETR\",\n            \"currency\": \"EUR\",\n            \"extra_data\": {},\n            \"categories\": [\n                {\n                    \"uuid\": \"20380e27-81f9-45ad-962a-b06fa3f77a55\",\n                    \"name\": \"Stocks\",\n                    \"code\": \"EQUITY\",\n                    \"order\": 2,\n                    \"type\": \"ASSET_CLASS\"\n                },\n                {\n                    \"uuid\": \"1223958a-04d7-49f1-8908-63a31180170b\",\n                    \"name\": \"Consumer Goods\",\n                    \"code\": \"CONSUMER_GOODS\",\n                    \"order\": 1,\n                    \"type\": \"CATEGORY\"\n                },\n                {\n                    \"uuid\": \"2612dfca-d742-4695-b0ee-668a973b0590\",\n                    \"name\": \"United States\",\n                    \"code\": \"UNITED_STATES\",\n                    \"order\": 1,\n                    \"type\": \"GEOGRAPHY\"\n                }\n            ],\n            \"asset_type\": \"STOCK\"\n        }\n    ]\n}"
+						}
+					]
+				},
+				{
+					"name": "ASSET PERFORMANCE retrieve",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{host}}:{{port}}/api/v2/assets/{{asset_uuid}}/performance/",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"api",
+								"v2",
+								"assets",
+								"{{asset_uuid}}",
+								"performance",
+								""
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "ok response",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{host}}:{{port}}/api/v2/assets/{{asset_uuid}}/performance/",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"api",
+										"v2",
+										"assets",
+										"{{asset_uuid}}",
+										"performance",
+										""
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Date",
+									"value": "Tue, 08 Mar 2022 08:35:31 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Content-Length",
+									"value": "196"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Server",
+									"value": "nginx"
+								},
+								{
+									"key": "Vary",
+									"value": "Accept, Origin, Accept-Language, Cookie"
+								},
+								{
+									"key": "Allow",
+									"value": "GET, HEAD, OPTIONS"
+								},
+								{
+									"key": "X-Frame-Options",
+									"value": "DENY"
+								},
+								{
+									"key": "Content-Language",
+									"value": "en-gb"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "Referrer-Policy",
+									"value": "same-origin"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=31536000; includeSubDomains"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"count\": 5,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"year\": 2018,\n            \"amount\": 21.05\n        },\n        {\n            \"year\": 2019,\n            \"amount\": 49.47\n        },\n        {\n            \"year\": 2020,\n            \"amount\": 3.83\n        },\n        {\n            \"year\": 2021,\n            \"amount\": 132.69\n        },\n        {\n            \"year\": 2022,\n            \"amount\": 29.68\n        }\n    ]\n}"
+						},
+						{
+							"name": "ok, ordering by year",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{host}}:{{port}}/api/v2/assets/{{asset_uuid}}/performance/?ordering=-year",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"api",
+										"v2",
+										"assets",
+										"{{asset_uuid}}",
+										"performance",
+										""
+									],
+									"query": [
+										{
+											"key": "ordering",
+											"value": "-year"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Date",
+									"value": "Tue, 08 Mar 2022 08:36:02 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Content-Length",
+									"value": "196"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Server",
+									"value": "nginx"
+								},
+								{
+									"key": "Vary",
+									"value": "Accept, Origin, Accept-Language, Cookie"
+								},
+								{
+									"key": "Allow",
+									"value": "GET, HEAD, OPTIONS"
+								},
+								{
+									"key": "X-Frame-Options",
+									"value": "DENY"
+								},
+								{
+									"key": "Content-Language",
+									"value": "en-gb"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "Referrer-Policy",
+									"value": "same-origin"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=31536000; includeSubDomains"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"count\": 5,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"year\": 2022,\n            \"amount\": 29.68\n        },\n        {\n            \"year\": 2021,\n            \"amount\": 132.69\n        },\n        {\n            \"year\": 2020,\n            \"amount\": 3.83\n        },\n        {\n            \"year\": 2019,\n            \"amount\": 49.47\n        },\n        {\n            \"year\": 2018,\n            \"amount\": 21.05\n        }\n    ]\n}"
 						}
 					]
 				}
@@ -4038,6 +4309,186 @@
 									],
 									"cookie": [],
 									"body": "{\n    \"count\": 2,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"a0d80f4b-e882-4d3a-bd38-e0aa4aa86033\",\n            \"description\": \"Service fee 0.75%\",\n            \"status\": \"CHARGED\",\n            \"amount\": 6.76,\n            \"balance\": 10613.598446,\n            \"extra_data\": {\n                \"fee\": {\n                    \"uuid\": \"None\",\n                    \"model\": \"InvestorFee\",\n                    \"value\": \"0.750000\",\n                    \"concept\": \"Service fee\",\n                    \"created\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"date_to\": \"None\",\n                    \"updated\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"fee_type\": \"portal_service\",\n                    \"amount_to\": \"100000.000000\",\n                    \"client_id\": \"6\",\n                    \"date_from\": \"None\",\n                    \"deleted_at\": \"None\",\n                    \"extra_data\": \"{}\",\n                    \"value_unit\": \"percentage\",\n                    \"amount_from\": \"0.000000\",\n                    \"minimum_fixed_value\": \"None\"\n                },\n                \"balance\": \"10613.59844599999996717087924480438232421875\",\n                \"concept\": \"Service fee\",\n                \"allocation_date\": \"2021-12-31\",\n                \"allocation_uuid\": \"ea15cd18-b0ac-42c3-b880-b2c33c5bbae8\"\n            },\n            \"external_id\": null,\n            \"charged\": \"2022-01-04T00:00:00.000000Z\",\n            \"created\": \"2022-01-05T08:01:00.000000Z\",\n            \"updated\": \"2022-01-05T08:01:00.000000Z\",\n            \"portfolio\": \"508ec859-9f66-4f75-b3a8-9e8b3039160f\"\n        },\n        {\n            \"uuid\": \"c84a6263-572a-4b31-848e-d4fef9e7a5e6\",\n            \"description\": \"paVHcgnkeBBpqCsAUSIJdoUDeCXgTFRTlufofXIKCfPDriLiyZOImRczsAOfrzftFxLeRjPIYmtkLKcwMcHTeTaFqvkMxNHedQps 3.76%\",\n            \"status\": \"CHARGED\",\n            \"amount\": 0,\n            \"balance\": 10613.598446,\n            \"extra_data\": {\n                \"fee\": {\n                    \"uuid\": \"4a932ea8-189f-4812-865b-3c4f6d7f8222\",\n                    \"model\": \"InvestorFee\",\n                    \"value\": \"3.760000\",\n                    \"concept\": \"paVHcgnkeBBpqCsAUSIJdoUDeCXgTFRTlufofXIKCfPDriLiyZOImRczsAOfrzftFxLeRjPIYmtkLKcwMcHTeTaFqvkMxNHedQps\",\n                    \"created\": \"2022-01-10 08:04:35.474564+00:00\",\n                    \"date_to\": \"None\",\n                    \"updated\": \"2022-01-10 08:04:35.474579+00:00\",\n                    \"fee_type\": \"seller_fee\",\n                    \"amount_to\": \"4.000000\",\n                    \"client_id\": \"6\",\n                    \"date_from\": \"None\",\n                    \"deleted_at\": \"None\",\n                    \"extra_data\": \"{}\",\n                    \"value_unit\": \"percentage\",\n                    \"amount_from\": \"3.000000\",\n                    \"minimum_fixed_value\": \"None\"\n                },\n                \"balance\": \"10613.59844599999996717087924480438232421875\",\n                \"concept\": \"paVHcgnkeBBpqCsAUSIJdoUDeCXgTFRTlufofXIKCfPDriLiyZOImRczsAOfrzftFxLeRjPIYmtkLKcwMcHTeTaFqvkMxNHedQps\",\n                \"allocation_date\": \"2021-12-31\",\n                \"allocation_uuid\": \"ea15cd18-b0ac-42c3-b880-b2c33c5bbae8\"\n            },\n            \"external_id\": null,\n            \"charged\": \"2022-01-05T08:01:00.000000Z\",\n            \"created\": \"2022-01-05T08:01:00.000000Z\",\n            \"updated\": \"2022-01-05T08:01:00.000000Z\",\n            \"portfolio\": \"508ec859-9f66-4f75-b3a8-9e8b3039160f\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "ok, ordering by charged",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "{{auth_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{host}}:{{port}}/api/v2/clients/{{client_uuid}}/billing/charges/?ordering=charged",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v2",
+												"clients",
+												"{{client_uuid}}",
+												"billing",
+												"charges",
+												""
+											],
+											"query": [
+												{
+													"key": "ordering",
+													"value": "charged"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Tue, 08 Mar 2022 08:55:35 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "3730"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Server",
+											"value": "nginx"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept, Origin, Accept-Language, Cookie"
+										},
+										{
+											"key": "Allow",
+											"value": "GET"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "DENY"
+										},
+										{
+											"key": "Content-Language",
+											"value": "en-gb"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Referrer-Policy",
+											"value": "same-origin"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000; includeSubDomains"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"count\": 4,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"d0433392-1e27-4ee7-8c93-00b3ce4f9da0\",\n            \"description\": \"Service fee 0.75%\",\n            \"status\": \"CHARGED\",\n            \"amount\": 6.55,\n            \"balance\": 10628.3231599,\n            \"extra_data\": {\n                \"fee\": {\n                    \"uuid\": \"None\",\n                    \"model\": \"InvestorFee\",\n                    \"value\": \"0.750000\",\n                    \"concept\": \"Service fee\",\n                    \"created\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"date_to\": \"None\",\n                    \"updated\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"fee_type\": \"portal_service\",\n                    \"amount_to\": \"100000.000000\",\n                    \"client_id\": \"7\",\n                    \"date_from\": \"None\",\n                    \"deleted_at\": \"None\",\n                    \"extra_data\": \"{}\",\n                    \"value_unit\": \"percentage\",\n                    \"amount_from\": \"0.000000\",\n                    \"minimum_fixed_value\": \"None\"\n                },\n                \"balance\": \"10628.32315989999915473163127899169921875\",\n                \"concept\": \"Service fee\",\n                \"allocation_date\": \"2021-11-29\",\n                \"allocation_uuid\": \"3451b460-c6f1-4ac6-ab93-40323144dad6\"\n            },\n            \"external_id\": null,\n            \"charged\": \"2021-12-02T07:07:00.000000Z\",\n            \"created\": \"2021-12-01T07:07:00.000000Z\",\n            \"updated\": \"2021-12-02T07:07:00.000000Z\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\"\n        },\n        {\n            \"uuid\": \"af4596cd-779e-4259-80e5-1ebfe59adf5f\",\n            \"description\": \"Service fee 0.75%\",\n            \"status\": \"CHARGED\",\n            \"amount\": 8.12,\n            \"balance\": 12753.015336774193,\n            \"extra_data\": {\n                \"fee\": {\n                    \"uuid\": \"None\",\n                    \"model\": \"InvestorFee\",\n                    \"value\": \"0.750000\",\n                    \"concept\": \"Service fee\",\n                    \"created\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"date_to\": \"None\",\n                    \"updated\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"fee_type\": \"portal_service\",\n                    \"amount_to\": \"100000.000000\",\n                    \"client_id\": \"7\",\n                    \"date_from\": \"None\",\n                    \"deleted_at\": \"None\",\n                    \"extra_data\": \"{}\",\n                    \"value_unit\": \"percentage\",\n                    \"amount_from\": \"0.000000\",\n                    \"minimum_fixed_value\": \"None\"\n                },\n                \"balance\": \"12753.015336774193201563321053981781005859375\",\n                \"concept\": \"Service fee\",\n                \"allocation_date\": \"2021-12-30\",\n                \"allocation_uuid\": \"cb95b3f9-f7ee-4507-b971-58f744facdb9\"\n            },\n            \"external_id\": null,\n            \"charged\": \"2022-01-04T07:07:00.000000Z\",\n            \"created\": \"2022-01-03T07:07:00.000000Z\",\n            \"updated\": \"2022-01-04T07:07:00.000000Z\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\"\n        },\n        {\n            \"uuid\": \"a8ef6f20-5867-4a83-b9f7-614bd2935cbd\",\n            \"description\": \"Service fee 0.75%\",\n            \"status\": \"CHARGED\",\n            \"amount\": 9.81,\n            \"balance\": 15396.363444290322,\n            \"extra_data\": {\n                \"fee\": {\n                    \"uuid\": \"None\",\n                    \"model\": \"InvestorFee\",\n                    \"value\": \"0.750000\",\n                    \"concept\": \"Service fee\",\n                    \"created\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"date_to\": \"None\",\n                    \"updated\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"fee_type\": \"portal_service\",\n                    \"amount_to\": \"100000.000000\",\n                    \"client_id\": \"7\",\n                    \"date_from\": \"None\",\n                    \"deleted_at\": \"None\",\n                    \"extra_data\": \"{}\",\n                    \"value_unit\": \"percentage\",\n                    \"amount_from\": \"0.000000\",\n                    \"minimum_fixed_value\": \"None\"\n                },\n                \"balance\": \"15396.363444290322149754501879215240478515625\",\n                \"concept\": \"Service fee\",\n                \"allocation_date\": \"2022-01-28\",\n                \"allocation_uuid\": \"ea5e5f2b-6496-4a3d-a716-f149f0db580a\"\n            },\n            \"external_id\": null,\n            \"charged\": \"2022-02-02T07:07:00.000000Z\",\n            \"created\": \"2022-02-01T07:07:00.000000Z\",\n            \"updated\": \"2022-02-02T07:07:00.000000Z\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\"\n        },\n        {\n            \"uuid\": \"e8b6a63b-1561-44a8-afde-2d0961554615\",\n            \"description\": \"Service fee 0.75%\",\n            \"status\": \"CHARGED\",\n            \"amount\": 10.02,\n            \"balance\": 17407.341762250002,\n            \"extra_data\": {\n                \"fee\": {\n                    \"uuid\": \"None\",\n                    \"model\": \"InvestorFee\",\n                    \"value\": \"0.750000\",\n                    \"concept\": \"Service fee\",\n                    \"created\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"date_to\": \"None\",\n                    \"updated\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"fee_type\": \"portal_service\",\n                    \"amount_to\": \"100000.000000\",\n                    \"client_id\": \"7\",\n                    \"date_from\": \"None\",\n                    \"deleted_at\": \"None\",\n                    \"extra_data\": \"{}\",\n                    \"value_unit\": \"percentage\",\n                    \"amount_from\": \"0.000000\",\n                    \"minimum_fixed_value\": \"None\"\n                },\n                \"balance\": \"17407.34176225000192061997950077056884765625\",\n                \"concept\": \"Service fee\",\n                \"allocation_date\": \"2022-02-25\",\n                \"allocation_uuid\": \"4f93ee10-5ee2-4118-a3e6-cacf77f10277\"\n            },\n            \"external_id\": null,\n            \"charged\": \"2022-03-02T07:07:00.000000Z\",\n            \"created\": \"2022-03-01T07:07:00.000000Z\",\n            \"updated\": \"2022-03-02T07:07:00.000000Z\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "ok, ordering by created",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "{{auth_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{host}}:{{port}}/api/v2/clients/{{client_uuid}}/billing/charges/?ordering=created",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v2",
+												"clients",
+												"{{client_uuid}}",
+												"billing",
+												"charges",
+												""
+											],
+											"query": [
+												{
+													"key": "ordering",
+													"value": "created"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Tue, 08 Mar 2022 08:56:08 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "3730"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Server",
+											"value": "nginx"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept, Origin, Accept-Language, Cookie"
+										},
+										{
+											"key": "Allow",
+											"value": "GET"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "DENY"
+										},
+										{
+											"key": "Content-Language",
+											"value": "en-gb"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Referrer-Policy",
+											"value": "same-origin"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000; includeSubDomains"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"count\": 4,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"d0433392-1e27-4ee7-8c93-00b3ce4f9da0\",\n            \"description\": \"Service fee 0.75%\",\n            \"status\": \"CHARGED\",\n            \"amount\": 6.55,\n            \"balance\": 10628.3231599,\n            \"extra_data\": {\n                \"fee\": {\n                    \"uuid\": \"None\",\n                    \"model\": \"InvestorFee\",\n                    \"value\": \"0.750000\",\n                    \"concept\": \"Service fee\",\n                    \"created\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"date_to\": \"None\",\n                    \"updated\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"fee_type\": \"portal_service\",\n                    \"amount_to\": \"100000.000000\",\n                    \"client_id\": \"7\",\n                    \"date_from\": \"None\",\n                    \"deleted_at\": \"None\",\n                    \"extra_data\": \"{}\",\n                    \"value_unit\": \"percentage\",\n                    \"amount_from\": \"0.000000\",\n                    \"minimum_fixed_value\": \"None\"\n                },\n                \"balance\": \"10628.32315989999915473163127899169921875\",\n                \"concept\": \"Service fee\",\n                \"allocation_date\": \"2021-11-29\",\n                \"allocation_uuid\": \"3451b460-c6f1-4ac6-ab93-40323144dad6\"\n            },\n            \"external_id\": null,\n            \"charged\": \"2021-12-02T07:07:00.000000Z\",\n            \"created\": \"2021-12-01T07:07:00.000000Z\",\n            \"updated\": \"2021-12-02T07:07:00.000000Z\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\"\n        },\n        {\n            \"uuid\": \"af4596cd-779e-4259-80e5-1ebfe59adf5f\",\n            \"description\": \"Service fee 0.75%\",\n            \"status\": \"CHARGED\",\n            \"amount\": 8.12,\n            \"balance\": 12753.015336774193,\n            \"extra_data\": {\n                \"fee\": {\n                    \"uuid\": \"None\",\n                    \"model\": \"InvestorFee\",\n                    \"value\": \"0.750000\",\n                    \"concept\": \"Service fee\",\n                    \"created\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"date_to\": \"None\",\n                    \"updated\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"fee_type\": \"portal_service\",\n                    \"amount_to\": \"100000.000000\",\n                    \"client_id\": \"7\",\n                    \"date_from\": \"None\",\n                    \"deleted_at\": \"None\",\n                    \"extra_data\": \"{}\",\n                    \"value_unit\": \"percentage\",\n                    \"amount_from\": \"0.000000\",\n                    \"minimum_fixed_value\": \"None\"\n                },\n                \"balance\": \"12753.015336774193201563321053981781005859375\",\n                \"concept\": \"Service fee\",\n                \"allocation_date\": \"2021-12-30\",\n                \"allocation_uuid\": \"cb95b3f9-f7ee-4507-b971-58f744facdb9\"\n            },\n            \"external_id\": null,\n            \"charged\": \"2022-01-04T07:07:00.000000Z\",\n            \"created\": \"2022-01-03T07:07:00.000000Z\",\n            \"updated\": \"2022-01-04T07:07:00.000000Z\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\"\n        },\n        {\n            \"uuid\": \"a8ef6f20-5867-4a83-b9f7-614bd2935cbd\",\n            \"description\": \"Service fee 0.75%\",\n            \"status\": \"CHARGED\",\n            \"amount\": 9.81,\n            \"balance\": 15396.363444290322,\n            \"extra_data\": {\n                \"fee\": {\n                    \"uuid\": \"None\",\n                    \"model\": \"InvestorFee\",\n                    \"value\": \"0.750000\",\n                    \"concept\": \"Service fee\",\n                    \"created\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"date_to\": \"None\",\n                    \"updated\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"fee_type\": \"portal_service\",\n                    \"amount_to\": \"100000.000000\",\n                    \"client_id\": \"7\",\n                    \"date_from\": \"None\",\n                    \"deleted_at\": \"None\",\n                    \"extra_data\": \"{}\",\n                    \"value_unit\": \"percentage\",\n                    \"amount_from\": \"0.000000\",\n                    \"minimum_fixed_value\": \"None\"\n                },\n                \"balance\": \"15396.363444290322149754501879215240478515625\",\n                \"concept\": \"Service fee\",\n                \"allocation_date\": \"2022-01-28\",\n                \"allocation_uuid\": \"ea5e5f2b-6496-4a3d-a716-f149f0db580a\"\n            },\n            \"external_id\": null,\n            \"charged\": \"2022-02-02T07:07:00.000000Z\",\n            \"created\": \"2022-02-01T07:07:00.000000Z\",\n            \"updated\": \"2022-02-02T07:07:00.000000Z\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\"\n        },\n        {\n            \"uuid\": \"e8b6a63b-1561-44a8-afde-2d0961554615\",\n            \"description\": \"Service fee 0.75%\",\n            \"status\": \"CHARGED\",\n            \"amount\": 10.02,\n            \"balance\": 17407.341762250002,\n            \"extra_data\": {\n                \"fee\": {\n                    \"uuid\": \"None\",\n                    \"model\": \"InvestorFee\",\n                    \"value\": \"0.750000\",\n                    \"concept\": \"Service fee\",\n                    \"created\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"date_to\": \"None\",\n                    \"updated\": \"2017-05-16 13:18:39.660000+00:00\",\n                    \"fee_type\": \"portal_service\",\n                    \"amount_to\": \"100000.000000\",\n                    \"client_id\": \"7\",\n                    \"date_from\": \"None\",\n                    \"deleted_at\": \"None\",\n                    \"extra_data\": \"{}\",\n                    \"value_unit\": \"percentage\",\n                    \"amount_from\": \"0.000000\",\n                    \"minimum_fixed_value\": \"None\"\n                },\n                \"balance\": \"17407.34176225000192061997950077056884765625\",\n                \"concept\": \"Service fee\",\n                \"allocation_date\": \"2022-02-25\",\n                \"allocation_uuid\": \"4f93ee10-5ee2-4118-a3e6-cacf77f10277\"\n            },\n            \"external_id\": null,\n            \"charged\": \"2022-03-02T07:07:00.000000Z\",\n            \"created\": \"2022-03-01T07:07:00.000000Z\",\n            \"updated\": \"2022-03-02T07:07:00.000000Z\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\"\n        }\n    ]\n}"
 								}
 							]
 						},
@@ -4795,7 +5246,97 @@
 									]
 								}
 							},
-							"response": []
+							"response": [
+								{
+									"name": "ok, ordering by created",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "{{auth_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{host}}:{{port}}/api/v2/clients/{{client_uuid}}/documents/?ordering=-created",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v2",
+												"clients",
+												"{{client_uuid}}",
+												"documents",
+												""
+											],
+											"query": [
+												{
+													"key": "ordering",
+													"value": "-created"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Wed, 09 Mar 2022 07:45:34 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "697"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Server",
+											"value": "nginx"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept, Origin, Accept-Language, Cookie"
+										},
+										{
+											"key": "Allow",
+											"value": "GET, POST"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "DENY"
+										},
+										{
+											"key": "Content-Language",
+											"value": "en-gb"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Referrer-Policy",
+											"value": "same-origin"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000; includeSubDomains"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"count\": 2,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"daec64d4-2b4a-4456-8d99-bede3c9a0cac\",\n            \"name\": \"path\",\n            \"doc_type\": \"PENSION\",\n            \"description\": \"HELLO\",\n            \"path\": \"https://multi1-sandbox.nucoro.com/media/documents/clients/e9f39707-f0f3-4a77-a119-4826354e9e5a/2022-03-09_07-45-04/Screenshot_2022-02-11_at_13.40.47.png\",\n            \"extra_data\": {},\n            \"created\": \"2022-03-09T07:45:04.159632Z\"\n        },\n        {\n            \"uuid\": \"50c22d0c-8d00-4348-853b-9b49da304eba\",\n            \"name\": \"path\",\n            \"doc_type\": \"PENSION\",\n            \"description\": \"HELLO\",\n            \"path\": \"https://multi1-sandbox.nucoro.com/media/documents/clients/e9f39707-f0f3-4a77-a119-4826354e9e5a/2022-03-09_07-44-31/Screenshot_2022-02-11_at_13.40.47.png\",\n            \"extra_data\": {},\n            \"created\": \"2022-03-09T07:44:31.286792Z\"\n        }\n    ]\n}"
+								}
+							]
 						},
 						{
 							"name": "CLIENT DOCUMENT get",
@@ -6204,6 +6745,186 @@
 									],
 									"cookie": [],
 									"body": "{\n    \"count\": 1,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"37714bc2-edbc-4940-8e88-f7bc8c03f5fd\",\n            \"number\": \"OPSION-2021-1\",\n            \"status\": \"CHARGED\",\n            \"date_from\": \"2021-02-01\",\n            \"date_to\": \"2021-02-28\",\n            \"amount\": 2.35,\n            \"charges\": [\n                \"7ba32b54-c841-45c8-a224-40af3c03fb13\"\n            ]\n        }\n    ]\n}"
+								},
+								{
+									"name": "ok, ordering date_from",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "{{auth_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{host}}:{{port}}/api/v2/clients/{{client_uuid}}/billing/invoices/?ordering=date_from",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v2",
+												"clients",
+												"{{client_uuid}}",
+												"billing",
+												"invoices",
+												""
+											],
+											"query": [
+												{
+													"key": "ordering",
+													"value": "date_from"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Tue, 08 Mar 2022 08:54:34 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "880"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Server",
+											"value": "nginx"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept, Origin, Accept-Language, Cookie"
+										},
+										{
+											"key": "Allow",
+											"value": "GET"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "DENY"
+										},
+										{
+											"key": "Content-Language",
+											"value": "en-gb"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Referrer-Policy",
+											"value": "same-origin"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000; includeSubDomains"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"count\": 4,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"ee8a32d0-f964-4776-bad8-3743ef2c1461\",\n            \"number\": \"sandbox-2021-10\",\n            \"status\": \"CHARGED\",\n            \"date_from\": \"2021-11-01\",\n            \"date_to\": \"2021-11-30\",\n            \"amount\": 6.55,\n            \"charges\": [\n                \"d0433392-1e27-4ee7-8c93-00b3ce4f9da0\"\n            ]\n        },\n        {\n            \"uuid\": \"423c5200-b718-4579-8995-0849343b98ed\",\n            \"number\": \"sandbox-2022-16\",\n            \"status\": \"CHARGED\",\n            \"date_from\": \"2021-12-01\",\n            \"date_to\": \"2021-12-31\",\n            \"amount\": 8.12,\n            \"charges\": [\n                \"af4596cd-779e-4259-80e5-1ebfe59adf5f\"\n            ]\n        },\n        {\n            \"uuid\": \"fc9ba517-aa4e-447d-aa23-8a2d45129c0d\",\n            \"number\": \"sandbox-2022-17\",\n            \"status\": \"CHARGED\",\n            \"date_from\": \"2022-01-01\",\n            \"date_to\": \"2022-01-31\",\n            \"amount\": 9.81,\n            \"charges\": [\n                \"a8ef6f20-5867-4a83-b9f7-614bd2935cbd\"\n            ]\n        },\n        {\n            \"uuid\": \"4a11673a-f449-4d10-a152-8a3a0f9e81da\",\n            \"number\": \"sandbox-2022-18\",\n            \"status\": \"CHARGED\",\n            \"date_from\": \"2022-02-01\",\n            \"date_to\": \"2022-02-28\",\n            \"amount\": 10.02,\n            \"charges\": [\n                \"e8b6a63b-1561-44a8-afde-2d0961554615\"\n            ]\n        }\n    ]\n}"
+								},
+								{
+									"name": "ok, ordering by date_to",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "{{auth_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{host}}:{{port}}/api/v2/clients/{{client_uuid}}/billing/invoices/?ordering=date_to",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v2",
+												"clients",
+												"{{client_uuid}}",
+												"billing",
+												"invoices",
+												""
+											],
+											"query": [
+												{
+													"key": "ordering",
+													"value": "date_to"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Tue, 08 Mar 2022 08:54:52 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "880"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Server",
+											"value": "nginx"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept, Origin, Accept-Language, Cookie"
+										},
+										{
+											"key": "Allow",
+											"value": "GET"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "DENY"
+										},
+										{
+											"key": "Content-Language",
+											"value": "en-gb"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Referrer-Policy",
+											"value": "same-origin"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000; includeSubDomains"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"count\": 4,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"ee8a32d0-f964-4776-bad8-3743ef2c1461\",\n            \"number\": \"sandbox-2021-10\",\n            \"status\": \"CHARGED\",\n            \"date_from\": \"2021-11-01\",\n            \"date_to\": \"2021-11-30\",\n            \"amount\": 6.55,\n            \"charges\": [\n                \"d0433392-1e27-4ee7-8c93-00b3ce4f9da0\"\n            ]\n        },\n        {\n            \"uuid\": \"423c5200-b718-4579-8995-0849343b98ed\",\n            \"number\": \"sandbox-2022-16\",\n            \"status\": \"CHARGED\",\n            \"date_from\": \"2021-12-01\",\n            \"date_to\": \"2021-12-31\",\n            \"amount\": 8.12,\n            \"charges\": [\n                \"af4596cd-779e-4259-80e5-1ebfe59adf5f\"\n            ]\n        },\n        {\n            \"uuid\": \"fc9ba517-aa4e-447d-aa23-8a2d45129c0d\",\n            \"number\": \"sandbox-2022-17\",\n            \"status\": \"CHARGED\",\n            \"date_from\": \"2022-01-01\",\n            \"date_to\": \"2022-01-31\",\n            \"amount\": 9.81,\n            \"charges\": [\n                \"a8ef6f20-5867-4a83-b9f7-614bd2935cbd\"\n            ]\n        },\n        {\n            \"uuid\": \"4a11673a-f449-4d10-a152-8a3a0f9e81da\",\n            \"number\": \"sandbox-2022-18\",\n            \"status\": \"CHARGED\",\n            \"date_from\": \"2022-02-01\",\n            \"date_to\": \"2022-02-28\",\n            \"amount\": 10.02,\n            \"charges\": [\n                \"e8b6a63b-1561-44a8-afde-2d0961554615\"\n            ]\n        }\n    ]\n}"
 								}
 							]
 						},
@@ -8506,6 +9227,276 @@
 									],
 									"cookie": [],
 									"body": "{\n    \"count\": 1,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"a0a0e4b3-c3ee-4360-92e2-d57d0b053b98\",\n            \"date_from\": \"2021-06-18\",\n            \"date_to\": \"2021-06-18\",\n            \"created\": \"2021-06-18T12:16:40.972401Z\",\n            \"status\": \"COMPLETED\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "ok, order by created date",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "{{auth_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{host}}:{{port}}/api/v2/clients/{{client_uuid}}/report/statements/?ordering=created",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v2",
+												"clients",
+												"{{client_uuid}}",
+												"report",
+												"statements",
+												""
+											],
+											"query": [
+												{
+													"key": "ordering",
+													"value": "created"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Wed, 09 Mar 2022 07:37:52 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "365"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Server",
+											"value": "nginx"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept, Origin, Accept-Language, Cookie"
+										},
+										{
+											"key": "Allow",
+											"value": "GET"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "DENY"
+										},
+										{
+											"key": "Content-Language",
+											"value": "en-gb"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Referrer-Policy",
+											"value": "same-origin"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000; includeSubDomains"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"count\": 2,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"61ee80c6-507f-4ed7-8361-e3b6bd24a614\",\n            \"date_from\": \"2021-09-09\",\n            \"date_to\": \"2021-12-09\",\n            \"created\": \"2022-03-09T07:37:09.944228Z\",\n            \"status\": \"COMPLETED\"\n        },\n        {\n            \"uuid\": \"5e2a3665-69ab-42b0-8802-7d809268d322\",\n            \"date_from\": \"2021-12-09\",\n            \"date_to\": \"2022-03-09\",\n            \"created\": \"2022-03-09T07:37:17.176214Z\",\n            \"status\": \"COMPLETED\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "ok, order by date_to",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "{{auth_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{host}}:{{port}}/api/v2/clients/{{client_uuid}}/report/statements/?ordering=date_to",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v2",
+												"clients",
+												"{{client_uuid}}",
+												"report",
+												"statements",
+												""
+											],
+											"query": [
+												{
+													"key": "ordering",
+													"value": "date_to"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Wed, 09 Mar 2022 07:38:26 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "365"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Server",
+											"value": "nginx"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept, Origin, Accept-Language, Cookie"
+										},
+										{
+											"key": "Allow",
+											"value": "GET"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "DENY"
+										},
+										{
+											"key": "Content-Language",
+											"value": "en-gb"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Referrer-Policy",
+											"value": "same-origin"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000; includeSubDomains"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"count\": 2,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"61ee80c6-507f-4ed7-8361-e3b6bd24a614\",\n            \"date_from\": \"2021-09-09\",\n            \"date_to\": \"2021-12-09\",\n            \"created\": \"2022-03-09T07:37:09.944228Z\",\n            \"status\": \"COMPLETED\"\n        },\n        {\n            \"uuid\": \"5e2a3665-69ab-42b0-8802-7d809268d322\",\n            \"date_from\": \"2021-12-09\",\n            \"date_to\": \"2022-03-09\",\n            \"created\": \"2022-03-09T07:37:17.176214Z\",\n            \"status\": \"COMPLETED\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "ok, order by date_from",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "{{auth_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{host}}:{{port}}/api/v2/clients/{{client_uuid}}/report/statements/?ordering=date_from",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v2",
+												"clients",
+												"{{client_uuid}}",
+												"report",
+												"statements",
+												""
+											],
+											"query": [
+												{
+													"key": "ordering",
+													"value": "date_from"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Wed, 09 Mar 2022 07:38:56 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "365"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Server",
+											"value": "nginx"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept, Origin, Accept-Language, Cookie"
+										},
+										{
+											"key": "Allow",
+											"value": "GET"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "DENY"
+										},
+										{
+											"key": "Content-Language",
+											"value": "en-gb"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Referrer-Policy",
+											"value": "same-origin"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000; includeSubDomains"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"count\": 2,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"5e2a3665-69ab-42b0-8802-7d809268d322\",\n            \"date_from\": \"2021-12-09\",\n            \"date_to\": \"2022-03-09\",\n            \"created\": \"2022-03-09T07:37:17.176214Z\",\n            \"status\": \"COMPLETED\"\n        },\n        {\n            \"uuid\": \"61ee80c6-507f-4ed7-8361-e3b6bd24a614\",\n            \"date_from\": \"2021-09-09\",\n            \"date_to\": \"2021-12-09\",\n            \"created\": \"2022-03-09T07:37:09.944228Z\",\n            \"status\": \"COMPLETED\"\n        }\n    ]\n}"
 								}
 							]
 						},
@@ -9526,6 +10517,276 @@
 									],
 									"cookie": [],
 									"body": "{\n    \"count\": 1,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"02f3293e-911d-4b05-b0fc-e4580f454f16\",\n            \"date_from\": \"2021-06-18\",\n            \"date_to\": \"2021-06-18\",\n            \"created\": \"2021-06-18T12:20:44.108860Z\",\n            \"status\": \"COMPLETED\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "ok, order by created",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "{{auth_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{host}}:{{port}}/api/v2/clients/{{client_uuid}}/report/tax-reports/?ordering=created",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v2",
+												"clients",
+												"{{client_uuid}}",
+												"report",
+												"tax-reports",
+												""
+											],
+											"query": [
+												{
+													"key": "ordering",
+													"value": "created"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Wed, 09 Mar 2022 07:39:48 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "365"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Server",
+											"value": "nginx"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept, Origin, Accept-Language, Cookie"
+										},
+										{
+											"key": "Allow",
+											"value": "GET"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "DENY"
+										},
+										{
+											"key": "Content-Language",
+											"value": "en-gb"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Referrer-Policy",
+											"value": "same-origin"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000; includeSubDomains"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"count\": 2,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"2d5d7e89-1f58-47ba-9bd0-5c16a53599b7\",\n            \"date_from\": \"2021-01-01\",\n            \"date_to\": \"2021-12-31\",\n            \"created\": \"2022-03-09T07:36:41.453087Z\",\n            \"status\": \"COMPLETED\"\n        },\n        {\n            \"uuid\": \"7e086845-0782-4af2-b7f7-5a5121cef2c0\",\n            \"date_from\": \"2022-01-01\",\n            \"date_to\": \"2022-12-31\",\n            \"created\": \"2022-03-09T07:36:48.190284Z\",\n            \"status\": \"COMPLETED\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "ok, order by date_to",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "{{auth_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{host}}:{{port}}/api/v2/clients/{{client_uuid}}/report/tax-reports/?ordering=-date_to",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v2",
+												"clients",
+												"{{client_uuid}}",
+												"report",
+												"tax-reports",
+												""
+											],
+											"query": [
+												{
+													"key": "ordering",
+													"value": "-date_to"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Wed, 09 Mar 2022 07:40:07 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "365"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Server",
+											"value": "nginx"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept, Origin, Accept-Language, Cookie"
+										},
+										{
+											"key": "Allow",
+											"value": "GET"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "DENY"
+										},
+										{
+											"key": "Content-Language",
+											"value": "en-gb"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Referrer-Policy",
+											"value": "same-origin"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000; includeSubDomains"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"count\": 2,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"7e086845-0782-4af2-b7f7-5a5121cef2c0\",\n            \"date_from\": \"2022-01-01\",\n            \"date_to\": \"2022-12-31\",\n            \"created\": \"2022-03-09T07:36:48.190284Z\",\n            \"status\": \"COMPLETED\"\n        },\n        {\n            \"uuid\": \"2d5d7e89-1f58-47ba-9bd0-5c16a53599b7\",\n            \"date_from\": \"2021-01-01\",\n            \"date_to\": \"2021-12-31\",\n            \"created\": \"2022-03-09T07:36:41.453087Z\",\n            \"status\": \"COMPLETED\"\n        }\n    ]\n}"
+								},
+								{
+									"name": "ok, order by date_from",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "{{auth_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{host}}:{{port}}/api/v2/clients/{{client_uuid}}/report/tax-reports/?ordering=date_from",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v2",
+												"clients",
+												"{{client_uuid}}",
+												"report",
+												"tax-reports",
+												""
+											],
+											"query": [
+												{
+													"key": "ordering",
+													"value": "date_from"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Wed, 09 Mar 2022 07:40:21 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "365"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Server",
+											"value": "nginx"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept, Origin, Accept-Language, Cookie"
+										},
+										{
+											"key": "Allow",
+											"value": "GET"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "DENY"
+										},
+										{
+											"key": "Content-Language",
+											"value": "en-gb"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Referrer-Policy",
+											"value": "same-origin"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000; includeSubDomains"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"count\": 2,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"2d5d7e89-1f58-47ba-9bd0-5c16a53599b7\",\n            \"date_from\": \"2021-01-01\",\n            \"date_to\": \"2021-12-31\",\n            \"created\": \"2022-03-09T07:36:41.453087Z\",\n            \"status\": \"COMPLETED\"\n        },\n        {\n            \"uuid\": \"7e086845-0782-4af2-b7f7-5a5121cef2c0\",\n            \"date_from\": \"2022-01-01\",\n            \"date_to\": \"2022-12-31\",\n            \"created\": \"2022-03-09T07:36:48.190284Z\",\n            \"status\": \"COMPLETED\"\n        }\n    ]\n}"
 								}
 							]
 						},
@@ -16453,6 +17714,94 @@
 							],
 							"cookie": [],
 							"body": "{\n    \"count\": 20,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"asset\": {\n                \"uuid\": \"4224db43-fb60-4604-aa87-b3404900c4dd\",\n                \"market\": \"XSWX\",\n                \"isin\": \"LU1493705955\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"LU1493705955.XSWS\",\n                \"name\": \"MFM Allegro\",\n                \"extra_data\": {},\n                \"categories\": [\n                    9,\n                    38\n                ]\n            },\n            \"trade\": \"1caf53ec-fbd0-4c91-9ba1-68b2f8bda280\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-03-11T00:00:00.000000Z\",\n            \"rebalance\": \"bb8d41ca-4970-4401-a610-441c00ff1ece\",\n            \"portfolio\": null,\n            \"shares\": 0.839952,\n            \"amount\": 94.805304,\n            \"price_avg\": 112.869907,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:49.881470Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"4eed76b8-87f1-43f4-8511-c6ad3fbc6449\",\n                \"market\": \"XSWX\",\n                \"isin\": \"IE00BQQP9G91\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"GDXJ.XSWX\",\n                \"name\": \"VanEck Investments Ltd - VanEck Vectors Junior Gold Miners UCITS ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    9,\n                    30,\n                    37\n                ]\n            },\n            \"trade\": \"e74c5b0f-0e48-48d2-89db-a8c7622122aa\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-03-11T00:00:00.000000Z\",\n            \"rebalance\": \"bb8d41ca-4970-4401-a610-441c00ff1ece\",\n            \"portfolio\": null,\n            \"shares\": 0.840826,\n            \"amount\": 39.560828,\n            \"price_avg\": 47.049959,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:49.872326Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"3bf6f5d1-108a-4b44-b8ee-5bd5d9514dcd\",\n                \"market\": \"XSWX\",\n                \"isin\": \"LU0514695690\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"XMCH.XSWX\",\n                \"name\": \"Deutsche Bank Luxembourg S.A. - Xtrackers MSCI China UCITS ETF 1C\",\n                \"extra_data\": {},\n                \"categories\": [\n                    16,\n                    35\n                ]\n            },\n            \"trade\": \"b0118016-0d5e-412d-8222-133bbc3167bb\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-03-11T00:00:00.000000Z\",\n            \"rebalance\": \"bb8d41ca-4970-4401-a610-441c00ff1ece\",\n            \"portfolio\": null,\n            \"shares\": 5.743695,\n            \"amount\": 115.218503,\n            \"price_avg\": 20.059997,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:49.863451Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"0465e0fa-8853-49ca-b279-cefe2849b381\",\n                \"market\": \"XSWX\",\n                \"isin\": \"LU1324516720\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"SBEMS.XSWX\",\n                \"name\": \"UBS Bloomberg Barclays USD Emerging Markets Sovereign UCITS ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    9,\n                    33,\n                    36\n                ]\n            },\n            \"trade\": \"f6d13c86-093a-4557-b2b6-86281360146a\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-03-11T00:00:00.000000Z\",\n            \"rebalance\": \"bb8d41ca-4970-4401-a610-441c00ff1ece\",\n            \"portfolio\": null,\n            \"shares\": 15.946724,\n            \"amount\": 195.985226,\n            \"price_avg\": 12.29,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:49.855393Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"e1c8c332-05d0-4ef9-814d-4ffc1d3c98eb\",\n                \"market\": \"XSWX\",\n                \"isin\": \"IE00BYPLS672\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"ISPY.XSWX\",\n                \"name\": \"L&G Cyber Security UCITS ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    3,\n                    9,\n                    35\n                ]\n            },\n            \"trade\": \"a02c07c7-395a-4fe4-a1b4-274ce0c4629a\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-03-11T00:00:00.000000Z\",\n            \"rebalance\": \"bb8d41ca-4970-4401-a610-441c00ff1ece\",\n            \"portfolio\": null,\n            \"shares\": 29.994024,\n            \"amount\": 528.37471,\n            \"price_avg\": 17.616,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:49.847318Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"5fc55166-3242-4642-b25c-ef3547a0939d\",\n                \"market\": \"XSWX\",\n                \"isin\": \"IE00B3RBWM25\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"VWRL.XSWX\",\n                \"name\": \"Vanguard FTSE All World UCITS ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    9,\n                    35\n                ]\n            },\n            \"trade\": \"b8bcba9d-f170-4ee1-9d19-f5e8e4b4f327\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-03-11T00:00:00.000000Z\",\n            \"rebalance\": \"bb8d41ca-4970-4401-a610-441c00ff1ece\",\n            \"portfolio\": null,\n            \"shares\": 3.513313,\n            \"amount\": 298.543394,\n            \"price_avg\": 84.974893,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:49.840448Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"57c54292-3150-4c66-a138-f8415efd097b\",\n                \"market\": \"XSWX\",\n                \"isin\": \"CH0226976816\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"CHCORP.XSWX\",\n                \"name\": \"iShares Core CHF Corporate Bond UCITS ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    9,\n                    21,\n                    36\n                ]\n            },\n            \"trade\": \"76ef0330-cefd-424d-9b98-989393658b63\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-03-11T00:00:00.000000Z\",\n            \"rebalance\": \"bb8d41ca-4970-4401-a610-441c00ff1ece\",\n            \"portfolio\": null,\n            \"shares\": 1.318301,\n            \"amount\": 131.750948,\n            \"price_avg\": 99.93996,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:49.830729Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"b730811c-8d20-40fb-bf28-c81377436cb0\",\n                \"market\": \"XSWX\",\n                \"isin\": \"CH0226274246\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"SWICHA.XSWX\",\n                \"name\": \"UBS MSCI Switzerland UCITS ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    17,\n                    35\n                ]\n            },\n            \"trade\": \"271d2ed7-6dbe-4e9f-9da3-c88ca24ad04c\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-03-11T00:00:00.000000Z\",\n            \"rebalance\": \"bb8d41ca-4970-4401-a610-441c00ff1ece\",\n            \"portfolio\": null,\n            \"shares\": 13.344228,\n            \"amount\": 252.986555,\n            \"price_avg\": 18.958501,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:49.821973Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"0e7b84da-3caf-4580-bc20-a4980848b058\",\n                \"market\": \"XSWX\",\n                \"isin\": \"CH0105994401\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"SRECHA.XSWX\",\n                \"name\": \"UBS SXI Real Estate ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    9,\n                    25,\n                    37\n                ]\n            },\n            \"trade\": \"32b15f41-57c9-47c7-97af-aa3d8e7a5934\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-03-11T00:00:00.000000Z\",\n            \"rebalance\": \"bb8d41ca-4970-4401-a610-441c00ff1ece\",\n            \"portfolio\": null,\n            \"shares\": 1.941516,\n            \"amount\": 123.420191,\n            \"price_avg\": 63.56898,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:49.813189Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"63e73b97-e5b4-4c01-92a6-523f55cd47f1\",\n                \"market\": \"XSWX\",\n                \"isin\": \"CH0016999861\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"CSBGC0.XSWX\",\n                \"name\": \"iShares Swiss Domestic Government Bond 7-15 Years ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    9,\n                    26,\n                    36\n                ]\n            },\n            \"trade\": \"e46159d3-82a2-40c7-8ecf-19474d2bbd3d\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-03-11T00:00:00.000000Z\",\n            \"rebalance\": \"bb8d41ca-4970-4401-a610-441c00ff1ece\",\n            \"portfolio\": null,\n            \"shares\": 1.176473,\n            \"amount\": 138.517904,\n            \"price_avg\": 117.739978,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:49.806052Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"4224db43-fb60-4604-aa87-b3404900c4dd\",\n                \"market\": \"XSWX\",\n                \"isin\": \"LU1493705955\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"LU1493705955.XSWS\",\n                \"name\": \"MFM Allegro\",\n                \"extra_data\": {},\n                \"categories\": [\n                    9,\n                    38\n                ]\n            },\n            \"trade\": \"c4d05516-10e5-4950-a2f6-e7f5c00a52e2\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-02-11T00:00:00.000000Z\",\n            \"rebalance\": \"335e2637-ef29-40ed-8817-e7bd7d63d32c\",\n            \"portfolio\": null,\n            \"shares\": 4.361759,\n            \"amount\": 490.000001,\n            \"price_avg\": 112.339999,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:41.021012Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"4eed76b8-87f1-43f4-8511-c6ad3fbc6449\",\n                \"market\": \"XSWX\",\n                \"isin\": \"IE00BQQP9G91\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"GDXJ.XSWX\",\n                \"name\": \"VanEck Investments Ltd - VanEck Vectors Junior Gold Miners UCITS ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    9,\n                    30,\n                    37\n                ]\n            },\n            \"trade\": \"d48a6100-c117-4225-acac-7b0d6a72f24c\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-02-11T00:00:00.000000Z\",\n            \"rebalance\": \"335e2637-ef29-40ed-8817-e7bd7d63d32c\",\n            \"portfolio\": null,\n            \"shares\": 6.646321,\n            \"amount\": 294.000001,\n            \"price_avg\": 44.234999,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:41.012907Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"3bf6f5d1-108a-4b44-b8ee-5bd5d9514dcd\",\n                \"market\": \"XSWX\",\n                \"isin\": \"LU0514695690\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"XMCH.XSWX\",\n                \"name\": \"Deutsche Bank Luxembourg S.A. - Xtrackers MSCI China UCITS ETF 1C\",\n                \"extra_data\": {},\n                \"categories\": [\n                    16,\n                    35\n                ]\n            },\n            \"trade\": \"90d4c5ab-c574-4c5a-a533-a76dafbf8afb\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-02-11T00:00:00.000000Z\",\n            \"rebalance\": \"335e2637-ef29-40ed-8817-e7bd7d63d32c\",\n            \"portfolio\": null,\n            \"shares\": 29.377964,\n            \"amount\": 588.000001,\n            \"price_avg\": 20.015002,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:41.005501Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"0465e0fa-8853-49ca-b279-cefe2849b381\",\n                \"market\": \"XSWX\",\n                \"isin\": \"LU1324516720\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"SBEMS.XSWX\",\n                \"name\": \"UBS Bloomberg Barclays USD Emerging Markets Sovereign UCITS ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    9,\n                    33,\n                    36\n                ]\n            },\n            \"trade\": \"3b101a5e-813d-456c-9f41-6224443394c5\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-02-11T00:00:00.000000Z\",\n            \"rebalance\": \"335e2637-ef29-40ed-8817-e7bd7d63d32c\",\n            \"portfolio\": null,\n            \"shares\": 79.597142,\n            \"amount\": 980.000001,\n            \"price_avg\": 12.312,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:40.996658Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"e1c8c332-05d0-4ef9-814d-4ffc1d3c98eb\",\n                \"market\": \"XSWX\",\n                \"isin\": \"IE00BYPLS672\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"ISPY.XSWX\",\n                \"name\": \"L&G Cyber Security UCITS ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    3,\n                    9,\n                    35\n                ]\n            },\n            \"trade\": \"f66151fd-1994-4118-a321-75661a885d01\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-02-11T00:00:00.000000Z\",\n            \"rebalance\": \"335e2637-ef29-40ed-8817-e7bd7d63d32c\",\n            \"portfolio\": null,\n            \"shares\": 123.31765,\n            \"amount\": 2254.000001,\n            \"price_avg\": 18.278,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:40.987831Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"5fc55166-3242-4642-b25c-ef3547a0939d\",\n                \"market\": \"XSWX\",\n                \"isin\": \"IE00B3RBWM25\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"VWRL.XSWX\",\n                \"name\": \"Vanguard FTSE All World UCITS ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    9,\n                    35\n                ]\n            },\n            \"trade\": \"20662c19-8008-40a8-83be-e46c8a49dee3\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-02-11T00:00:00.000000Z\",\n            \"rebalance\": \"335e2637-ef29-40ed-8817-e7bd7d63d32c\",\n            \"portfolio\": null,\n            \"shares\": 17.214586,\n            \"amount\": 1470.000001,\n            \"price_avg\": 85.392702,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:40.980452Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"57c54292-3150-4c66-a138-f8415efd097b\",\n                \"market\": \"XSWX\",\n                \"isin\": \"CH0226976816\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"CHCORP.XSWX\",\n                \"name\": \"iShares Core CHF Corporate Bond UCITS ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    9,\n                    21,\n                    36\n                ]\n            },\n            \"trade\": \"dcd7f810-bb27-476d-b100-569a9c3721e4\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-02-11T00:00:00.000000Z\",\n            \"rebalance\": \"335e2637-ef29-40ed-8817-e7bd7d63d32c\",\n            \"portfolio\": null,\n            \"shares\": 6.906273,\n            \"amount\": 686.000001,\n            \"price_avg\": 99.329987,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:40.972329Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"b730811c-8d20-40fb-bf28-c81377436cb0\",\n                \"market\": \"XSWX\",\n                \"isin\": \"CH0226274246\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"SWICHA.XSWX\",\n                \"name\": \"UBS MSCI Switzerland UCITS ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    17,\n                    35\n                ]\n            },\n            \"trade\": \"d9999e67-0d25-4033-865e-86cf88454125\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-02-11T00:00:00.000000Z\",\n            \"rebalance\": \"335e2637-ef29-40ed-8817-e7bd7d63d32c\",\n            \"portfolio\": null,\n            \"shares\": 79.561385,\n            \"amount\": 1470.000001,\n            \"price_avg\": 18.4763,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:40.962936Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"0e7b84da-3caf-4580-bc20-a4980848b058\",\n                \"market\": \"XSWX\",\n                \"isin\": \"CH0105994401\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"SRECHA.XSWX\",\n                \"name\": \"UBS SXI Real Estate ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    9,\n                    25,\n                    37\n                ]\n            },\n            \"trade\": \"4a573535-29ee-4d37-87c3-263afbb57abb\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-02-11T00:00:00.000000Z\",\n            \"rebalance\": \"335e2637-ef29-40ed-8817-e7bd7d63d32c\",\n            \"portfolio\": null,\n            \"shares\": 10.988747,\n            \"amount\": 686.000001,\n            \"price_avg\": 62.4275,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:40.954213Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        },\n        {\n            \"asset\": {\n                \"uuid\": \"63e73b97-e5b4-4c01-92a6-523f55cd47f1\",\n                \"market\": \"XSWX\",\n                \"isin\": \"CH0016999861\",\n                \"currency\": \"CHF\",\n                \"ticker\": \"CSBGC0.XSWX\",\n                \"name\": \"iShares Swiss Domestic Government Bond 7-15 Years ETF\",\n                \"extra_data\": {},\n                \"categories\": [\n                    9,\n                    26,\n                    36\n                ]\n            },\n            \"trade\": \"68efe0ea-d096-45a4-a1d7-e188588b1c74\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-02-11T00:00:00.000000Z\",\n            \"rebalance\": \"335e2637-ef29-40ed-8817-e7bd7d63d32c\",\n            \"portfolio\": null,\n            \"shares\": 5.804705,\n            \"amount\": 686.000001,\n            \"price_avg\": 118.179994,\n            \"currency\": {\n                \"code\": \"CHF\",\n                \"name\": \"Swiss franc\",\n                \"symbol\": \"Fr.\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-03-23T10:03:40.942613Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null\n        }\n    ]\n}"
+						},
+						{
+							"name": "ok, ordering by completed date",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{auth_token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{host}}:{{port}}/api/v2/broker/orders/?ordering=-completed",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"api",
+										"v2",
+										"broker",
+										"orders",
+										""
+									],
+									"query": [
+										{
+											"key": "ordering",
+											"value": "-completed"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Date",
+									"value": "Tue, 08 Mar 2022 08:46:38 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Content-Length",
+									"value": "7256"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Server",
+									"value": "nginx"
+								},
+								{
+									"key": "Vary",
+									"value": "Accept, Origin, Accept-Language, Cookie"
+								},
+								{
+									"key": "Allow",
+									"value": "GET, POST"
+								},
+								{
+									"key": "X-Frame-Options",
+									"value": "DENY"
+								},
+								{
+									"key": "Content-Language",
+									"value": "en-gb"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "Referrer-Policy",
+									"value": "same-origin"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=31536000; includeSubDomains"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"count\": 13,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"asset\": \"466204cc-a765-4125-b397-f5beea8fd9d3\",\n            \"trade\": \"8479359b-d5b7-4db0-ab6f-e5bb94326873\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2022-03-07T00:00:00.000000Z\",\n            \"rebalance\": \"241adcad-1d31-4a2f-aeab-9f297b521a20\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\",\n            \"shares\": 2,\n            \"amount\": 1564.690435,\n            \"price_avg\": 782.345218,\n            \"currency\": {\n                \"code\": \"GBP\",\n                \"name\": \"Great British Pound\",\n                \"symbol\": \"£\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-11-01T09:07:00.000000Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null,\n            \"fx_rate_account\": 1\n        },\n        {\n            \"asset\": \"75437e54-162b-49b2-a67d-1087c9121f9e\",\n            \"trade\": \"554ecd64-65ea-42de-bdc9-74cc93a772ee\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2022-03-07T00:00:00.000000Z\",\n            \"rebalance\": \"241adcad-1d31-4a2f-aeab-9f297b521a20\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\",\n            \"shares\": 50,\n            \"amount\": 2615.10679,\n            \"price_avg\": 52.302136,\n            \"currency\": {\n                \"code\": \"GBP\",\n                \"name\": \"Great British Pound\",\n                \"symbol\": \"£\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-11-01T09:07:00.000000Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null,\n            \"fx_rate_account\": 1\n        },\n        {\n            \"asset\": \"ade887dd-9894-417e-9cfa-ad08d377e9fb\",\n            \"trade\": \"99f640ab-d7aa-4c8d-8c8a-e6113be34cb6\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-11-01T00:00:00.000000Z\",\n            \"rebalance\": \"241adcad-1d31-4a2f-aeab-9f297b521a20\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\",\n            \"shares\": 1,\n            \"amount\": 33.594676,\n            \"price_avg\": 33.594676,\n            \"currency\": {\n                \"code\": \"GBP\",\n                \"name\": \"Great British Pound\",\n                \"symbol\": \"£\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-11-01T09:07:00.000000Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null,\n            \"fx_rate_account\": 1\n        },\n        {\n            \"asset\": \"c6260f8a-aba4-4435-9061-045934c00529\",\n            \"trade\": \"9e1594ba-7789-43c2-af5b-7f12dc5003eb\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-11-01T00:00:00.000000Z\",\n            \"rebalance\": \"241adcad-1d31-4a2f-aeab-9f297b521a20\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\",\n            \"shares\": 2,\n            \"amount\": 175.418391,\n            \"price_avg\": 87.709196,\n            \"currency\": {\n                \"code\": \"GBP\",\n                \"name\": \"Great British Pound\",\n                \"symbol\": \"£\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-11-01T09:07:00.000000Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null,\n            \"fx_rate_account\": 1\n        },\n        {\n            \"asset\": \"6ae02c6f-8cc9-4ee5-be86-511f088e878f\",\n            \"trade\": \"0dd7ee8d-d8fb-40f9-9555-cf70cd68f2c3\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-11-01T00:00:00.000000Z\",\n            \"rebalance\": \"241adcad-1d31-4a2f-aeab-9f297b521a20\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\",\n            \"shares\": 24,\n            \"amount\": 345.15348,\n            \"price_avg\": 14.381395,\n            \"currency\": {\n                \"code\": \"GBP\",\n                \"name\": \"Great British Pound\",\n                \"symbol\": \"£\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-11-01T09:07:00.000000Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null,\n            \"fx_rate_account\": 1\n        },\n        {\n            \"asset\": \"f296f05f-74f7-424d-9a5a-ec5b883b4ef8\",\n            \"trade\": \"a09d1713-683e-4994-809f-6d12c14b844a\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-11-01T00:00:00.000000Z\",\n            \"rebalance\": \"241adcad-1d31-4a2f-aeab-9f297b521a20\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\",\n            \"shares\": 49,\n            \"amount\": 718.776049,\n            \"price_avg\": 14.668899,\n            \"currency\": {\n                \"code\": \"GBP\",\n                \"name\": \"Great British Pound\",\n                \"symbol\": \"£\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-11-01T09:07:00.000000Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null,\n            \"fx_rate_account\": 1\n        },\n        {\n            \"asset\": \"62641ea0-d91c-443c-b240-aac43a7aa40e\",\n            \"trade\": \"4fa0d464-4dd0-4ac6-a807-755aa3b3f134\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-11-01T00:00:00.000000Z\",\n            \"rebalance\": \"241adcad-1d31-4a2f-aeab-9f297b521a20\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\",\n            \"shares\": 4,\n            \"amount\": 1045.619446,\n            \"price_avg\": 261.404862,\n            \"currency\": {\n                \"code\": \"GBP\",\n                \"name\": \"Great British Pound\",\n                \"symbol\": \"£\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-11-01T09:07:00.000000Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null,\n            \"fx_rate_account\": 1\n        },\n        {\n            \"asset\": \"7994fbb2-8772-4825-85ae-f70c98631c5d\",\n            \"trade\": \"45f4ffc8-39d3-4442-a122-576bffa1ec67\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-11-01T00:00:00.000000Z\",\n            \"rebalance\": \"241adcad-1d31-4a2f-aeab-9f297b521a20\",\n            \"portfolio\": \"c8790e99-6b87-430c-86e1-9d82faf67c8b\",\n            \"shares\": 68,\n            \"amount\": 2362.86334,\n            \"price_avg\": 34.74799,\n            \"currency\": {\n                \"code\": \"GBP\",\n                \"name\": \"Great British Pound\",\n                \"symbol\": \"£\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-11-01T09:07:00.000000Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null,\n            \"fx_rate_account\": 1\n        },\n        {\n            \"asset\": \"d99716a0-19c2-41c3-8337-7c4b0d589bc5\",\n            \"trade\": \"eb733025-6813-46b2-bde5-e2756c41de48\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-11-01T00:00:00.000000Z\",\n            \"rebalance\": null,\n            \"portfolio\": \"a897200d-3458-43c7-b38f-6af0fa75d1ee\",\n            \"shares\": 2,\n            \"amount\": 488.32,\n            \"price_avg\": 244.158442,\n            \"currency\": {\n                \"code\": \"USD\",\n                \"name\": \"United States Dollar\",\n                \"symbol\": \"$\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-11-01T00:00:00.000000Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null,\n            \"fx_rate_account\": 1.533673\n        },\n        {\n            \"asset\": \"75972b13-5735-4115-980b-c713bcf3ffe3\",\n            \"trade\": \"c85f03f4-a522-48c6-844e-2b8da0b1eaa9\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-11-01T00:00:00.000000Z\",\n            \"rebalance\": null,\n            \"portfolio\": \"a897200d-3458-43c7-b38f-6af0fa75d1ee\",\n            \"shares\": 2,\n            \"amount\": 853.32,\n            \"price_avg\": 426.6598,\n            \"currency\": {\n                \"code\": \"USD\",\n                \"name\": \"United States Dollar\",\n                \"symbol\": \"$\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-11-01T00:00:00.000000Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null,\n            \"fx_rate_account\": 1\n        },\n        {\n            \"asset\": \"9b2f6f74-0dbf-4248-9472-3e24c78062a9\",\n            \"trade\": \"e7b39a8d-5cd3-4d23-b961-96ed846a5b37\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-11-01T00:00:00.000000Z\",\n            \"rebalance\": null,\n            \"portfolio\": \"a897200d-3458-43c7-b38f-6af0fa75d1ee\",\n            \"shares\": 2,\n            \"amount\": 739.19,\n            \"price_avg\": 369.592643,\n            \"currency\": {\n                \"code\": \"USD\",\n                \"name\": \"United States Dollar\",\n                \"symbol\": \"$\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-11-01T00:00:00.000000Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null,\n            \"fx_rate_account\": 1.030367\n        },\n        {\n            \"asset\": \"ccc63948-6edc-4df2-a3ba-4fa132e9424e\",\n            \"trade\": \"a81dbc1f-3362-498a-98c0-9d587a1ee89e\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-11-01T00:00:00.000000Z\",\n            \"rebalance\": null,\n            \"portfolio\": \"a897200d-3458-43c7-b38f-6af0fa75d1ee\",\n            \"shares\": 2,\n            \"amount\": 60.4,\n            \"price_avg\": 30.198972,\n            \"currency\": {\n                \"code\": \"USD\",\n                \"name\": \"United States Dollar\",\n                \"symbol\": \"$\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-11-01T00:00:00.000000Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null,\n            \"fx_rate_account\": 1.296466\n        },\n        {\n            \"asset\": \"b28ef8e4-cecc-4d24-b436-308abe18717d\",\n            \"trade\": \"79c3a845-e3c9-4e55-af79-80a4449aa4a7\",\n            \"order_type\": \"BUY\",\n            \"method\": \"MARKET\",\n            \"status\": \"COMPLETED\",\n            \"reason\": \"\",\n            \"completed\": \"2021-11-01T00:00:00.000000Z\",\n            \"rebalance\": null,\n            \"portfolio\": \"a897200d-3458-43c7-b38f-6af0fa75d1ee\",\n            \"shares\": 2,\n            \"amount\": 88.53,\n            \"price_avg\": 44.262877,\n            \"currency\": {\n                \"code\": \"USD\",\n                \"name\": \"United States Dollar\",\n                \"symbol\": \"$\"\n            },\n            \"withdrawal\": null,\n            \"created\": \"2021-11-01T00:00:00.000000Z\",\n            \"stop_price\": null,\n            \"limit_price\": null,\n            \"duration\": null,\n            \"fx_rate_account\": 1.533673\n        }\n    ]\n}"
 						}
 					]
 				},
@@ -18471,6 +19820,96 @@
 									],
 									"cookie": [],
 									"body": "{\n    \"count\": 29,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"valuation_date\": \"2021-03-22\",\n            \"balance\": 11955.335928,\n            \"invested\": 12000,\n            \"earnings\": -44.664073,\n            \"cash_active\": 476.715887,\n            \"trade_total\": 11478.620041,\n            \"performance\": -0.30884\n        },\n        {\n            \"valuation_date\": \"2021-03-19\",\n            \"balance\": 11958.227332,\n            \"invested\": 12000,\n            \"earnings\": -41.772669,\n            \"cash_active\": 476.715887,\n            \"trade_total\": 11481.511445,\n            \"performance\": -0.28473\n        },\n        {\n            \"valuation_date\": \"2021-03-18\",\n            \"balance\": 11991.075806,\n            \"invested\": 12000,\n            \"earnings\": -8.924195,\n            \"cash_active\": 476.715887,\n            \"trade_total\": 11514.359919,\n            \"performance\": -0.010818\n        },\n        {\n            \"valuation_date\": \"2021-03-17\",\n            \"balance\": 11825.433507,\n            \"invested\": 12000,\n            \"earnings\": -174.566494,\n            \"cash_active\": 476.715887,\n            \"trade_total\": 11348.71762,\n            \"performance\": -1.392049\n        },\n        {\n            \"valuation_date\": \"2021-03-16\",\n            \"balance\": 11794.191642,\n            \"invested\": 12000,\n            \"earnings\": -205.808359,\n            \"cash_active\": 476.715887,\n            \"trade_total\": 11317.475755,\n            \"performance\": -1.652563\n        },\n        {\n            \"valuation_date\": \"2021-03-15\",\n            \"balance\": 11970.87751,\n            \"invested\": 12000,\n            \"earnings\": -29.122491,\n            \"cash_active\": 476.715887,\n            \"trade_total\": 11494.161623,\n            \"performance\": -0.179244\n        },\n        {\n            \"valuation_date\": \"2021-03-12\",\n            \"balance\": 11859.956299,\n            \"invested\": 12000,\n            \"earnings\": -140.043702,\n            \"cash_active\": 476.715887,\n            \"trade_total\": 11383.240412,\n            \"performance\": -1.104176\n        },\n        {\n            \"valuation_date\": \"2021-03-11\",\n            \"balance\": 11839.60045,\n            \"invested\": 12000,\n            \"earnings\": -160.399551,\n            \"cash_active\": 476.715887,\n            \"trade_total\": 11362.884563,\n            \"performance\": -1.273916\n        },\n        {\n            \"valuation_date\": \"2021-03-10\",\n            \"balance\": 12038.280096,\n            \"invested\": 12000,\n            \"earnings\": 38.280096,\n            \"cash_active\": 2393.63999,\n            \"trade_total\": 9644.640106,\n            \"performance\": 0.382801\n        },\n        {\n            \"valuation_date\": \"2021-03-09\",\n            \"balance\": 10020.299645,\n            \"invested\": 10000,\n            \"earnings\": 20.299645,\n            \"cash_active\": 393.63999,\n            \"trade_total\": 9626.659655,\n            \"performance\": 0.202996\n        },\n        {\n            \"valuation_date\": \"2021-03-08\",\n            \"balance\": 10100.930956,\n            \"invested\": 10000,\n            \"earnings\": 100.930956,\n            \"cash_active\": 393.63999,\n            \"trade_total\": 9707.290966,\n            \"performance\": 1.00931\n        },\n        {\n            \"valuation_date\": \"2021-03-05\",\n            \"balance\": 10086.620078,\n            \"invested\": 10000,\n            \"earnings\": 86.620078,\n            \"cash_active\": 393.63999,\n            \"trade_total\": 9692.980088,\n            \"performance\": 0.866201\n        },\n        {\n            \"valuation_date\": \"2021-03-04\",\n            \"balance\": 10001.022537,\n            \"invested\": 10000,\n            \"earnings\": 1.022537,\n            \"cash_active\": 393.63999,\n            \"trade_total\": 9607.382547,\n            \"performance\": 0.010225\n        },\n        {\n            \"valuation_date\": \"2021-03-03\",\n            \"balance\": 9994.324473,\n            \"invested\": 10000,\n            \"earnings\": -5.675528,\n            \"cash_active\": 393.63999,\n            \"trade_total\": 9600.684483,\n            \"performance\": -0.056755\n        },\n        {\n            \"valuation_date\": \"2021-03-02\",\n            \"balance\": 10011.874866,\n            \"invested\": 10000,\n            \"earnings\": 11.874866,\n            \"cash_active\": 393.63999,\n            \"trade_total\": 9618.234876,\n            \"performance\": 0.118749\n        },\n        {\n            \"valuation_date\": \"2021-03-01\",\n            \"balance\": 10026.803059,\n            \"invested\": 10000,\n            \"earnings\": 26.803059,\n            \"cash_active\": 393.63999,\n            \"trade_total\": 9633.163069,\n            \"performance\": 0.268031\n        },\n        {\n            \"valuation_date\": \"2021-02-26\",\n            \"balance\": 9984.488027,\n            \"invested\": 10000,\n            \"earnings\": -15.511974,\n            \"cash_active\": 395.99999,\n            \"trade_total\": 9588.488037,\n            \"performance\": -0.15512\n        },\n        {\n            \"valuation_date\": \"2021-02-25\",\n            \"balance\": 10019.459789,\n            \"invested\": 10000,\n            \"earnings\": 19.459789,\n            \"cash_active\": 395.99999,\n            \"trade_total\": 9623.459799,\n            \"performance\": 0.194598\n        },\n        {\n            \"valuation_date\": \"2021-02-24\",\n            \"balance\": 9974.643853,\n            \"invested\": 10000,\n            \"earnings\": -25.356148,\n            \"cash_active\": 395.99999,\n            \"trade_total\": 9578.643863,\n            \"performance\": -0.253561\n        },\n        {\n            \"valuation_date\": \"2021-02-23\",\n            \"balance\": 10135.581747,\n            \"invested\": 10000,\n            \"earnings\": 135.581747,\n            \"cash_active\": 395.99999,\n            \"trade_total\": 9739.581757,\n            \"performance\": 1.355817\n        },\n        {\n            \"valuation_date\": \"2021-02-22\",\n            \"balance\": 10231.271341,\n            \"invested\": 10000,\n            \"earnings\": 231.271341,\n            \"cash_active\": 395.99999,\n            \"trade_total\": 9835.271351,\n            \"performance\": 2.312713\n        },\n        {\n            \"valuation_date\": \"2021-02-19\",\n            \"balance\": 10105.635867,\n            \"invested\": 10000,\n            \"earnings\": 105.635867,\n            \"cash_active\": 395.99999,\n            \"trade_total\": 9709.635877,\n            \"performance\": 1.056359\n        },\n        {\n            \"valuation_date\": \"2021-02-18\",\n            \"balance\": 10086.838883,\n            \"invested\": 10000,\n            \"earnings\": 86.838883,\n            \"cash_active\": 395.99999,\n            \"trade_total\": 9690.838893,\n            \"performance\": 0.868389\n        },\n        {\n            \"valuation_date\": \"2021-02-17\",\n            \"balance\": 10063.526938,\n            \"invested\": 10000,\n            \"earnings\": 63.526938,\n            \"cash_active\": 395.99999,\n            \"trade_total\": 9667.526948,\n            \"performance\": 0.635269\n        },\n        {\n            \"valuation_date\": \"2021-02-16\",\n            \"balance\": 10101.88335,\n            \"invested\": 10000,\n            \"earnings\": 101.88335,\n            \"cash_active\": 395.99999,\n            \"trade_total\": 9705.88336,\n            \"performance\": 1.018834\n        },\n        {\n            \"valuation_date\": \"2021-02-15\",\n            \"balance\": 10085.955225,\n            \"invested\": 10000,\n            \"earnings\": 85.955225,\n            \"cash_active\": 395.99999,\n            \"trade_total\": 9689.955235,\n            \"performance\": 0.859552\n        },\n        {\n            \"valuation_date\": \"2021-02-12\",\n            \"balance\": 10081.273937,\n            \"invested\": 10000,\n            \"earnings\": 81.273937,\n            \"cash_active\": 395.99999,\n            \"trade_total\": 9685.273947,\n            \"performance\": 0.812739\n        },\n        {\n            \"valuation_date\": \"2021-02-11\",\n            \"balance\": 10077.604585,\n            \"invested\": 10000,\n            \"earnings\": 77.604585,\n            \"cash_active\": 395.99999,\n            \"trade_total\": 9681.604595,\n            \"performance\": 0.776046\n        },\n        {\n            \"valuation_date\": \"2021-02-10\",\n            \"balance\": 10000,\n            \"invested\": 10000,\n            \"earnings\": 0,\n            \"cash_active\": 10000,\n            \"trade_total\": 0,\n            \"performance\": 0\n        }\n    ]\n}"
+								},
+								{
+									"name": "ok, order by valuation_date",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "{{auth_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{host}}:{{port}}/api/v2/portfolios/{{portfolio_uuid}}/allocations/end-day/?ordering=valuation_date",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v2",
+												"portfolios",
+												"{{portfolio_uuid}}",
+												"allocations",
+												"end-day",
+												""
+											],
+											"query": [
+												{
+													"key": "ordering",
+													"value": "valuation_date"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Tue, 08 Mar 2022 08:31:09 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "14427"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Server",
+											"value": "nginx"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept, Origin, Accept-Language, Cookie"
+										},
+										{
+											"key": "Allow",
+											"value": "GET"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "DENY"
+										},
+										{
+											"key": "Content-Language",
+											"value": "en-gb"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Referrer-Policy",
+											"value": "same-origin"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000; includeSubDomains"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"count\": 90,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"valuation_date\": \"2021-10-29\",\n            \"balance\": 10000,\n            \"invested\": 10000,\n            \"earnings\": 0,\n            \"cash_active\": 10000,\n            \"trade_total\": 0,\n            \"performance\": 0\n        },\n        {\n            \"valuation_date\": \"2021-11-01\",\n            \"balance\": 9999.9916,\n            \"invested\": 10000,\n            \"earnings\": -0.0084,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1180.5016,\n            \"performance\": -0.000084\n        },\n        {\n            \"valuation_date\": \"2021-11-02\",\n            \"balance\": 9994.2652,\n            \"invested\": 10000,\n            \"earnings\": -5.7348,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1174.7752,\n            \"performance\": -0.057348\n        },\n        {\n            \"valuation_date\": \"2021-11-03\",\n            \"balance\": 9977.81,\n            \"invested\": 10000,\n            \"earnings\": -22.19,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1158.32,\n            \"performance\": -0.2219\n        },\n        {\n            \"valuation_date\": \"2021-11-04\",\n            \"balance\": 9986.6848,\n            \"invested\": 10000,\n            \"earnings\": -13.3152,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1167.1948,\n            \"performance\": -0.133152\n        },\n        {\n            \"valuation_date\": \"2021-11-05\",\n            \"balance\": 9998.8896,\n            \"invested\": 10000,\n            \"earnings\": -1.1104,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1179.3996,\n            \"performance\": -0.011104\n        },\n        {\n            \"valuation_date\": \"2021-11-08\",\n            \"balance\": 10006.3466,\n            \"invested\": 10000,\n            \"earnings\": 6.3466,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1186.8566,\n            \"performance\": 0.063466\n        },\n        {\n            \"valuation_date\": \"2021-11-09\",\n            \"balance\": 10021.1302,\n            \"invested\": 10000,\n            \"earnings\": 21.1302,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1201.6402,\n            \"performance\": 0.211302\n        },\n        {\n            \"valuation_date\": \"2021-11-10\",\n            \"balance\": 10021.15,\n            \"invested\": 10000,\n            \"earnings\": 21.15,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1201.66,\n            \"performance\": 0.2115\n        },\n        {\n            \"valuation_date\": \"2021-11-11\",\n            \"balance\": 10019.7168,\n            \"invested\": 10000,\n            \"earnings\": 19.7168,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1200.2268,\n            \"performance\": 0.197168\n        },\n        {\n            \"valuation_date\": \"2021-11-12\",\n            \"balance\": 9995.319,\n            \"invested\": 10000,\n            \"earnings\": -4.681,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1175.829,\n            \"performance\": -0.04681\n        },\n        {\n            \"valuation_date\": \"2021-11-15\",\n            \"balance\": 9984.6546,\n            \"invested\": 10000,\n            \"earnings\": -15.3454,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1165.1646,\n            \"performance\": -0.153454\n        },\n        {\n            \"valuation_date\": \"2021-11-16\",\n            \"balance\": 10007.4618,\n            \"invested\": 10000,\n            \"earnings\": 7.4618,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1187.9718,\n            \"performance\": 0.074618\n        },\n        {\n            \"valuation_date\": \"2021-11-17\",\n            \"balance\": 10022.1262,\n            \"invested\": 10000,\n            \"earnings\": 22.1262,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1202.6362,\n            \"performance\": 0.221262\n        },\n        {\n            \"valuation_date\": \"2021-11-18\",\n            \"balance\": 10038.7958,\n            \"invested\": 10000,\n            \"earnings\": 38.7958,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1219.3058,\n            \"performance\": 0.387958\n        },\n        {\n            \"valuation_date\": \"2021-11-19\",\n            \"balance\": 10033.7422,\n            \"invested\": 10000,\n            \"earnings\": 33.7422,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1214.2522,\n            \"performance\": 0.337422\n        },\n        {\n            \"valuation_date\": \"2021-11-22\",\n            \"balance\": 10036.0872,\n            \"invested\": 10000,\n            \"earnings\": 36.0872,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1216.5972,\n            \"performance\": 0.360872\n        },\n        {\n            \"valuation_date\": \"2021-11-23\",\n            \"balance\": 10035.487,\n            \"invested\": 10000,\n            \"earnings\": 35.487,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1215.997,\n            \"performance\": 0.35487\n        },\n        {\n            \"valuation_date\": \"2021-11-24\",\n            \"balance\": 10040.1858,\n            \"invested\": 10000,\n            \"earnings\": 40.1858,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1220.6958,\n            \"performance\": 0.401858\n        },\n        {\n            \"valuation_date\": \"2021-11-25\",\n            \"balance\": 10044.607,\n            \"invested\": 10000,\n            \"earnings\": 44.607,\n            \"cash_active\": 8819.49,\n            \"trade_total\": 1225.117,\n            \"performance\": 0.44607\n        },\n        {\n            \"valuation_date\": \"2021-11-26\",\n            \"balance\": 12074.6118,\n            \"invested\": 12000,\n            \"earnings\": 74.6118,\n            \"cash_active\": 10819.49,\n            \"trade_total\": 1255.1218,\n            \"performance\": 0.746118\n        },\n        {\n            \"valuation_date\": \"2021-11-29\",\n            \"balance\": 12066.4138,\n            \"invested\": 12000,\n            \"earnings\": 66.4138,\n            \"cash_active\": 10819.49,\n            \"trade_total\": 1246.9238,\n            \"performance\": 0.677717\n        },\n        {\n            \"valuation_date\": \"2021-11-30\",\n            \"balance\": 12061.4792,\n            \"invested\": 12000,\n            \"earnings\": 61.4792,\n            \"cash_active\": 10819.49,\n            \"trade_total\": 1241.9892,\n            \"performance\": 0.636544\n        },\n        {\n            \"valuation_date\": \"2021-12-01\",\n            \"balance\": 12053.184,\n            \"invested\": 12000,\n            \"earnings\": 53.184,\n            \"cash_active\": 10819.49,\n            \"trade_total\": 1233.694,\n            \"performance\": 0.567332\n        },\n        {\n            \"valuation_date\": \"2021-12-02\",\n            \"balance\": 12059.7062,\n            \"invested\": 12000,\n            \"earnings\": 59.7062,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1246.5862,\n            \"performance\": 0.621751\n        },\n        {\n            \"valuation_date\": \"2021-12-03\",\n            \"balance\": 12060.2914,\n            \"invested\": 12000,\n            \"earnings\": 60.2914,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1247.1714,\n            \"performance\": 0.626634\n        },\n        {\n            \"valuation_date\": \"2021-12-06\",\n            \"balance\": 12058.5956,\n            \"invested\": 12000,\n            \"earnings\": 58.5956,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1245.4756,\n            \"performance\": 0.612485\n        },\n        {\n            \"valuation_date\": \"2021-12-07\",\n            \"balance\": 12047.0372,\n            \"invested\": 12000,\n            \"earnings\": 47.0372,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1233.9172,\n            \"performance\": 0.516046\n        },\n        {\n            \"valuation_date\": \"2021-12-08\",\n            \"balance\": 12054.6834,\n            \"invested\": 12000,\n            \"earnings\": 54.6834,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1241.5634,\n            \"performance\": 0.579843\n        },\n        {\n            \"valuation_date\": \"2021-12-09\",\n            \"balance\": 12068.2758,\n            \"invested\": 12000,\n            \"earnings\": 68.2758,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1255.1558,\n            \"performance\": 0.693253\n        },\n        {\n            \"valuation_date\": \"2021-12-10\",\n            \"balance\": 12057.7304,\n            \"invested\": 12000,\n            \"earnings\": 57.7304,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1244.6104,\n            \"performance\": 0.605266\n        },\n        {\n            \"valuation_date\": \"2021-12-13\",\n            \"balance\": 12049.517,\n            \"invested\": 12000,\n            \"earnings\": 49.517,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1236.397,\n            \"performance\": 0.536736\n        },\n        {\n            \"valuation_date\": \"2021-12-14\",\n            \"balance\": 12053.941,\n            \"invested\": 12000,\n            \"earnings\": 53.941,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1240.821,\n            \"performance\": 0.573648\n        },\n        {\n            \"valuation_date\": \"2021-12-15\",\n            \"balance\": 12054.5884,\n            \"invested\": 12000,\n            \"earnings\": 54.5884,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1241.4684,\n            \"performance\": 0.57905\n        },\n        {\n            \"valuation_date\": \"2021-12-16\",\n            \"balance\": 12046.0362,\n            \"invested\": 12000,\n            \"earnings\": 46.0362,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1232.9162,\n            \"performance\": 0.507694\n        },\n        {\n            \"valuation_date\": \"2021-12-17\",\n            \"balance\": 12035.6828,\n            \"invested\": 12000,\n            \"earnings\": 35.6828,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1222.5628,\n            \"performance\": 0.421309\n        },\n        {\n            \"valuation_date\": \"2021-12-20\",\n            \"balance\": 12032.5804,\n            \"invested\": 12000,\n            \"earnings\": 32.5804,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1219.4604,\n            \"performance\": 0.395423\n        },\n        {\n            \"valuation_date\": \"2021-12-21\",\n            \"balance\": 12045.6482,\n            \"invested\": 12000,\n            \"earnings\": 45.6482,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1232.5282,\n            \"performance\": 0.504456\n        },\n        {\n            \"valuation_date\": \"2021-12-22\",\n            \"balance\": 12045.8142,\n            \"invested\": 12000,\n            \"earnings\": 45.8142,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1232.6942,\n            \"performance\": 0.505841\n        },\n        {\n            \"valuation_date\": \"2021-12-23\",\n            \"balance\": 12040.8324,\n            \"invested\": 12000,\n            \"earnings\": 40.8324,\n            \"cash_active\": 10813.12,\n            \"trade_total\": 1227.7124,\n            \"performance\": 0.464275\n        },\n        {\n            \"valuation_date\": \"2021-12-27\",\n            \"balance\": 14022.0036,\n            \"invested\": 14000,\n            \"earnings\": 22.0036,\n            \"cash_active\": 12813.12,\n            \"trade_total\": 1208.8836,\n            \"performance\": 0.307175\n        },\n        {\n            \"valuation_date\": \"2021-12-28\",\n            \"balance\": 13998.4458,\n            \"invested\": 14000,\n            \"earnings\": -1.5542,\n            \"cash_active\": 12813.12,\n            \"trade_total\": 1185.3258,\n            \"performance\": 0.138653\n        },\n        {\n            \"valuation_date\": \"2021-12-29\",\n            \"balance\": 13998.7522,\n            \"invested\": 14000,\n            \"earnings\": -1.2478,\n            \"cash_active\": 12813.12,\n            \"trade_total\": 1185.6322,\n            \"performance\": 0.140844\n        },\n        {\n            \"valuation_date\": \"2021-12-30\",\n            \"balance\": 13997.3954,\n            \"invested\": 14000,\n            \"earnings\": -2.6046,\n            \"cash_active\": 12813.12,\n            \"trade_total\": 1184.2754,\n            \"performance\": 0.131138\n        },\n        {\n            \"valuation_date\": \"2022-01-03\",\n            \"balance\": 14013.6344,\n            \"invested\": 14000,\n            \"earnings\": 13.6344,\n            \"cash_active\": 12813.12,\n            \"trade_total\": 1200.5144,\n            \"performance\": 0.247305\n        },\n        {\n            \"valuation_date\": \"2022-01-04\",\n            \"balance\": 14010.9564,\n            \"invested\": 14000,\n            \"earnings\": 10.9564,\n            \"cash_active\": 12805.27,\n            \"trade_total\": 1205.6864,\n            \"performance\": 0.228148\n        },\n        {\n            \"valuation_date\": \"2022-01-05\",\n            \"balance\": 13999.6888,\n            \"invested\": 14000,\n            \"earnings\": -0.3112,\n            \"cash_active\": 12805.27,\n            \"trade_total\": 1194.4188,\n            \"performance\": 0.147544\n        },\n        {\n            \"valuation_date\": \"2022-01-06\",\n            \"balance\": 14009.37,\n            \"invested\": 14000,\n            \"earnings\": 9.37,\n            \"cash_active\": 12805.27,\n            \"trade_total\": 1204.1,\n            \"performance\": 0.216799\n        },\n        {\n            \"valuation_date\": \"2022-01-07\",\n            \"balance\": 14008.51,\n            \"invested\": 14000,\n            \"earnings\": 8.51,\n            \"cash_active\": 12805.27,\n            \"trade_total\": 1203.24,\n            \"performance\": 0.210647\n        },\n        {\n            \"valuation_date\": \"2022-01-10\",\n            \"balance\": 14030.6452,\n            \"invested\": 14000,\n            \"earnings\": 30.6452,\n            \"cash_active\": 12805.27,\n            \"trade_total\": 1225.3752,\n            \"performance\": 0.368993\n        },\n        {\n            \"valuation_date\": \"2022-01-11\",\n            \"balance\": 14050.883,\n            \"invested\": 14000,\n            \"earnings\": 50.883,\n            \"cash_active\": 12805.27,\n            \"trade_total\": 1245.613,\n            \"performance\": 0.513765\n        },\n        {\n            \"valuation_date\": \"2022-01-12\",\n            \"balance\": 14058.5308,\n            \"invested\": 14000,\n            \"earnings\": 58.5308,\n            \"cash_active\": 12805.27,\n            \"trade_total\": 1253.2608,\n            \"performance\": 0.568474\n        },\n        {\n            \"valuation_date\": \"2022-01-13\",\n            \"balance\": 14061.542,\n            \"invested\": 14000,\n            \"earnings\": 61.542,\n            \"cash_active\": 12805.27,\n            \"trade_total\": 1256.272,\n            \"performance\": 0.590015\n        },\n        {\n            \"valuation_date\": \"2022-01-14\",\n            \"balance\": 14063.4144,\n            \"invested\": 14000,\n            \"earnings\": 63.4144,\n            \"cash_active\": 12805.27,\n            \"trade_total\": 1258.1444,\n            \"performance\": 0.603409\n        },\n        {\n            \"valuation_date\": \"2022-01-17\",\n            \"balance\": 14070.8098,\n            \"invested\": 14000,\n            \"earnings\": 70.8098,\n            \"cash_active\": 12805.27,\n            \"trade_total\": 1265.5398,\n            \"performance\": 0.656312\n        },\n        {\n            \"valuation_date\": \"2022-01-18\",\n            \"balance\": 14043.0564,\n            \"invested\": 14000,\n            \"earnings\": 43.0564,\n            \"cash_active\": 12805.27,\n            \"trade_total\": 1237.7864,\n            \"performance\": 0.457777\n        },\n        {\n            \"valuation_date\": \"2022-01-19\",\n            \"balance\": 14062.2114,\n            \"invested\": 14000,\n            \"earnings\": 62.2114,\n            \"cash_active\": 12805.27,\n            \"trade_total\": 1256.9414,\n            \"performance\": 0.594803\n        },\n        {\n            \"valuation_date\": \"2022-01-20\",\n            \"balance\": 14045.012,\n            \"invested\": 14000,\n            \"earnings\": 45.012,\n            \"cash_active\": 12805.27,\n            \"trade_total\": 1239.742,\n            \"performance\": 0.471766\n        },\n        {\n            \"valuation_date\": \"2022-01-21\",\n            \"balance\": 16052.4426,\n            \"invested\": 16000,\n            \"earnings\": 52.4426,\n            \"cash_active\": 14805.27,\n            \"trade_total\": 1247.1726,\n            \"performance\": 0.524922\n        },\n        {\n            \"valuation_date\": \"2022-01-24\",\n            \"balance\": 16061.754,\n            \"invested\": 16000,\n            \"earnings\": 61.754,\n            \"cash_active\": 14805.27,\n            \"trade_total\": 1256.484,\n            \"performance\": 0.583232\n        },\n        {\n            \"valuation_date\": \"2022-01-25\",\n            \"balance\": 16071.566,\n            \"invested\": 16000,\n            \"earnings\": 71.566,\n            \"cash_active\": 14805.27,\n            \"trade_total\": 1266.296,\n            \"performance\": 0.644678\n        },\n        {\n            \"valuation_date\": \"2022-01-26\",\n            \"balance\": 16069.0084,\n            \"invested\": 16000,\n            \"earnings\": 69.0084,\n            \"cash_active\": 14805.27,\n            \"trade_total\": 1263.7384,\n            \"performance\": 0.628661\n        },\n        {\n            \"valuation_date\": \"2022-01-27\",\n            \"balance\": 16066.3112,\n            \"invested\": 16000,\n            \"earnings\": 66.3112,\n            \"cash_active\": 14805.27,\n            \"trade_total\": 1261.0412,\n            \"performance\": 0.611771\n        },\n        {\n            \"valuation_date\": \"2022-01-28\",\n            \"balance\": 16057.6566,\n            \"invested\": 16000,\n            \"earnings\": 57.6566,\n            \"cash_active\": 14805.27,\n            \"trade_total\": 1252.3866,\n            \"performance\": 0.557573\n        },\n        {\n            \"valuation_date\": \"2022-01-31\",\n            \"balance\": 16040.9522,\n            \"invested\": 16000,\n            \"earnings\": 40.9522,\n            \"cash_active\": 14805.27,\n            \"trade_total\": 1235.6822,\n            \"performance\": 0.452965\n        },\n        {\n            \"valuation_date\": \"2022-02-01\",\n            \"balance\": 16028.9162,\n            \"invested\": 16000,\n            \"earnings\": 28.9162,\n            \"cash_active\": 14805.27,\n            \"trade_total\": 1223.6462,\n            \"performance\": 0.377593\n        },\n        {\n            \"valuation_date\": \"2022-02-02\",\n            \"balance\": 16025.339,\n            \"invested\": 16000,\n            \"earnings\": 25.339,\n            \"cash_active\": 14795.91,\n            \"trade_total\": 1229.429,\n            \"performance\": 0.355191\n        },\n        {\n            \"valuation_date\": \"2022-02-03\",\n            \"balance\": 16013.0132,\n            \"invested\": 16000,\n            \"earnings\": 13.0132,\n            \"cash_active\": 14795.91,\n            \"trade_total\": 1217.1032,\n            \"performance\": 0.278004\n        },\n        {\n            \"valuation_date\": \"2022-02-04\",\n            \"balance\": 16003.7752,\n            \"invested\": 16000,\n            \"earnings\": 3.7752,\n            \"cash_active\": 14795.91,\n            \"trade_total\": 1207.8652,\n            \"performance\": 0.220153\n        },\n        {\n            \"valuation_date\": \"2022-02-07\",\n            \"balance\": 16022.1592,\n            \"invested\": 16000,\n            \"earnings\": 22.1592,\n            \"cash_active\": 14795.91,\n            \"trade_total\": 1226.2492,\n            \"performance\": 0.335278\n        },\n        {\n            \"valuation_date\": \"2022-02-08\",\n            \"balance\": 16020.36,\n            \"invested\": 16000,\n            \"earnings\": 20.36,\n            \"cash_active\": 14795.91,\n            \"trade_total\": 1224.45,\n            \"performance\": 0.324011\n        },\n        {\n            \"valuation_date\": \"2022-02-09\",\n            \"balance\": 16022.8566,\n            \"invested\": 16000,\n            \"earnings\": 22.8566,\n            \"cash_active\": 14795.91,\n            \"trade_total\": 1226.9466,\n            \"performance\": 0.339646\n        },\n        {\n            \"valuation_date\": \"2022-02-10\",\n            \"balance\": 16029.2722,\n            \"invested\": 16000,\n            \"earnings\": 29.2722,\n            \"cash_active\": 14795.91,\n            \"trade_total\": 1233.3622,\n            \"performance\": 0.379822\n        },\n        {\n            \"valuation_date\": \"2022-02-11\",\n            \"balance\": 16020.9978,\n            \"invested\": 16000,\n            \"earnings\": 20.9978,\n            \"cash_active\": 14795.91,\n            \"trade_total\": 1225.0878,\n            \"performance\": 0.328005\n        },\n        {\n            \"valuation_date\": \"2022-02-14\",\n            \"balance\": 15996.2978,\n            \"invested\": 16000,\n            \"earnings\": -3.7022,\n            \"cash_active\": 14795.91,\n            \"trade_total\": 1200.3878,\n            \"performance\": 0.173327\n        },\n        {\n            \"valuation_date\": \"2022-02-15\",\n            \"balance\": 16007.1828,\n            \"invested\": 16000,\n            \"earnings\": 7.1828,\n            \"cash_active\": 14795.91,\n            \"trade_total\": 1211.2728,\n            \"performance\": 0.241492\n        },\n        {\n            \"valuation_date\": \"2022-02-16\",\n            \"balance\": 15985.3998,\n            \"invested\": 16000,\n            \"earnings\": -14.6002,\n            \"cash_active\": 14795.91,\n            \"trade_total\": 1189.4898,\n            \"performance\": 0.105081\n        },\n        {\n            \"valuation_date\": \"2022-02-17\",\n            \"balance\": 15967.3372,\n            \"invested\": 16000,\n            \"earnings\": -32.6628,\n            \"cash_active\": 14795.91,\n            \"trade_total\": 1171.4272,\n            \"performance\": -0.008032\n        },\n        {\n            \"valuation_date\": \"2022-02-18\",\n            \"balance\": 17956.3862,\n            \"invested\": 18000,\n            \"earnings\": -43.6138,\n            \"cash_active\": 16795.91,\n            \"trade_total\": 1160.4762,\n            \"performance\": -0.076611\n        },\n        {\n            \"valuation_date\": \"2022-02-21\",\n            \"balance\": 17955.51,\n            \"invested\": 18000,\n            \"earnings\": -44.49,\n            \"cash_active\": 16795.91,\n            \"trade_total\": 1159.6,\n            \"performance\": -0.081487\n        },\n        {\n            \"valuation_date\": \"2022-02-22\",\n            \"balance\": 17955.7038,\n            \"invested\": 18000,\n            \"earnings\": -44.2962,\n            \"cash_active\": 16795.91,\n            \"trade_total\": 1159.7938,\n            \"performance\": -0.080408\n        },\n        {\n            \"valuation_date\": \"2022-02-23\",\n            \"balance\": 17962.5434,\n            \"invested\": 18000,\n            \"earnings\": -37.4566,\n            \"cash_active\": 16795.91,\n            \"trade_total\": 1166.6334,\n            \"performance\": -0.042347\n        },\n        {\n            \"valuation_date\": \"2022-02-24\",\n            \"balance\": 17982.2936,\n            \"invested\": 18000,\n            \"earnings\": -17.7064,\n            \"cash_active\": 16795.91,\n            \"trade_total\": 1186.3836,\n            \"performance\": 0.067558\n        },\n        {\n            \"valuation_date\": \"2022-02-25\",\n            \"balance\": 17971.08,\n            \"invested\": 18000,\n            \"earnings\": -28.92,\n            \"cash_active\": 16795.91,\n            \"trade_total\": 1175.17,\n            \"performance\": 0.005157\n        },\n        {\n            \"valuation_date\": \"2022-02-28\",\n            \"balance\": 17981.2114,\n            \"invested\": 18000,\n            \"earnings\": -18.7886,\n            \"cash_active\": 16795.91,\n            \"trade_total\": 1185.3014,\n            \"performance\": 0.061536\n        },\n        {\n            \"valuation_date\": \"2022-03-01\",\n            \"balance\": 17990.0218,\n            \"invested\": 18000,\n            \"earnings\": -9.9782,\n            \"cash_active\": 16795.91,\n            \"trade_total\": 1194.1118,\n            \"performance\": 0.110564\n        },\n        {\n            \"valuation_date\": \"2022-03-02\",\n            \"balance\": 17988.905,\n            \"invested\": 18000,\n            \"earnings\": -11.095,\n            \"cash_active\": 16786.27,\n            \"trade_total\": 1202.635,\n            \"performance\": 0.104349\n        },\n        {\n            \"valuation_date\": \"2022-03-03\",\n            \"balance\": 17971.4096,\n            \"invested\": 18000,\n            \"earnings\": -28.5904,\n            \"cash_active\": 16786.27,\n            \"trade_total\": 1185.1396,\n            \"performance\": 0.006991\n        },\n        {\n            \"valuation_date\": \"2022-03-04\",\n            \"balance\": 17981.7192,\n            \"invested\": 18000,\n            \"earnings\": -18.2808,\n            \"cash_active\": 16786.27,\n            \"trade_total\": 1195.4492,\n            \"performance\": 0.064362\n        },\n        {\n            \"valuation_date\": \"2022-03-07\",\n            \"balance\": 17979.1694,\n            \"invested\": 18000,\n            \"earnings\": -20.8306,\n            \"cash_active\": 16786.27,\n            \"trade_total\": 1192.8994,\n            \"performance\": 0.050173\n        }\n    ]\n}"
 								}
 							]
 						},
@@ -19451,6 +20890,96 @@
 									],
 									"cookie": [],
 									"body": "{\n    \"count\": 29,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"valuation_date\": \"2021-02-10\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-02-11\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-02-12\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-02-15\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-02-16\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-02-17\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-02-18\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-02-19\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-02-22\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-02-23\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-02-24\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-02-25\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-02-26\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-01\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-02\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-03\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-04\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-05\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-08\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-09\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-10\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-11\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-12\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-15\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-16\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-17\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-18\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-19\",\n            \"percentage\": -100\n        },\n        {\n            \"valuation_date\": \"2021-03-22\",\n            \"percentage\": -100\n        }\n    ]\n}"
+								},
+								{
+									"name": "ok, ordering valuation_date",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "{{auth_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{host}}:{{port}}/api/v2/portfolios/{{portfolio_uuid}}/performance/twrr/?ordering=-valuation_date",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v2",
+												"portfolios",
+												"{{portfolio_uuid}}",
+												"performance",
+												"twrr",
+												""
+											],
+											"query": [
+												{
+													"key": "ordering",
+													"value": "-valuation_date"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Tue, 08 Mar 2022 08:32:32 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "5110"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Server",
+											"value": "nginx"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept, Origin, Accept-Language, Cookie"
+										},
+										{
+											"key": "Allow",
+											"value": "GET"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "DENY"
+										},
+										{
+											"key": "Content-Language",
+											"value": "en-gb"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Referrer-Policy",
+											"value": "same-origin"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000; includeSubDomains"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"count\": 92,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"valuation_date\": \"2022-03-07\",\n            \"performance\": 0.050173\n        },\n        {\n            \"valuation_date\": \"2022-03-04\",\n            \"performance\": 0.064362\n        },\n        {\n            \"valuation_date\": \"2022-03-03\",\n            \"performance\": 0.006992\n        },\n        {\n            \"valuation_date\": \"2022-03-02\",\n            \"performance\": 0.10435\n        },\n        {\n            \"valuation_date\": \"2022-03-01\",\n            \"performance\": 0.110565\n        },\n        {\n            \"valuation_date\": \"2022-02-28\",\n            \"performance\": 0.061537\n        },\n        {\n            \"valuation_date\": \"2022-02-25\",\n            \"performance\": 0.005158\n        },\n        {\n            \"valuation_date\": \"2022-02-24\",\n            \"performance\": 0.067559\n        },\n        {\n            \"valuation_date\": \"2022-02-23\",\n            \"performance\": -0.042348\n        },\n        {\n            \"valuation_date\": \"2022-02-22\",\n            \"performance\": -0.080409\n        },\n        {\n            \"valuation_date\": \"2022-02-21\",\n            \"performance\": -0.081487\n        },\n        {\n            \"valuation_date\": \"2022-02-18\",\n            \"performance\": -0.076611\n        },\n        {\n            \"valuation_date\": \"2022-02-17\",\n            \"performance\": -0.008033\n        },\n        {\n            \"valuation_date\": \"2022-02-16\",\n            \"performance\": 0.105081\n        },\n        {\n            \"valuation_date\": \"2022-02-15\",\n            \"performance\": 0.241492\n        },\n        {\n            \"valuation_date\": \"2022-02-14\",\n            \"performance\": 0.173328\n        },\n        {\n            \"valuation_date\": \"2022-02-11\",\n            \"performance\": 0.328006\n        },\n        {\n            \"valuation_date\": \"2022-02-10\",\n            \"performance\": 0.379823\n        },\n        {\n            \"valuation_date\": \"2022-02-09\",\n            \"performance\": 0.339646\n        },\n        {\n            \"valuation_date\": \"2022-02-08\",\n            \"performance\": 0.324012\n        },\n        {\n            \"valuation_date\": \"2022-02-07\",\n            \"performance\": 0.335279\n        },\n        {\n            \"valuation_date\": \"2022-02-04\",\n            \"performance\": 0.220153\n        },\n        {\n            \"valuation_date\": \"2022-02-03\",\n            \"performance\": 0.278004\n        },\n        {\n            \"valuation_date\": \"2022-02-02\",\n            \"performance\": 0.355192\n        },\n        {\n            \"valuation_date\": \"2022-02-01\",\n            \"performance\": 0.377593\n        },\n        {\n            \"valuation_date\": \"2022-01-31\",\n            \"performance\": 0.452966\n        },\n        {\n            \"valuation_date\": \"2022-01-28\",\n            \"performance\": 0.557574\n        },\n        {\n            \"valuation_date\": \"2022-01-27\",\n            \"performance\": 0.611771\n        },\n        {\n            \"valuation_date\": \"2022-01-26\",\n            \"performance\": 0.628662\n        },\n        {\n            \"valuation_date\": \"2022-01-25\",\n            \"performance\": 0.644678\n        },\n        {\n            \"valuation_date\": \"2022-01-24\",\n            \"performance\": 0.583233\n        },\n        {\n            \"valuation_date\": \"2022-01-21\",\n            \"performance\": 0.524922\n        },\n        {\n            \"valuation_date\": \"2022-01-20\",\n            \"performance\": 0.471767\n        },\n        {\n            \"valuation_date\": \"2022-01-19\",\n            \"performance\": 0.594804\n        },\n        {\n            \"valuation_date\": \"2022-01-18\",\n            \"performance\": 0.457777\n        },\n        {\n            \"valuation_date\": \"2022-01-17\",\n            \"performance\": 0.656313\n        },\n        {\n            \"valuation_date\": \"2022-01-14\",\n            \"performance\": 0.603409\n        },\n        {\n            \"valuation_date\": \"2022-01-13\",\n            \"performance\": 0.590015\n        },\n        {\n            \"valuation_date\": \"2022-01-12\",\n            \"performance\": 0.568474\n        },\n        {\n            \"valuation_date\": \"2022-01-11\",\n            \"performance\": 0.513765\n        },\n        {\n            \"valuation_date\": \"2022-01-10\",\n            \"performance\": 0.368993\n        },\n        {\n            \"valuation_date\": \"2022-01-07\",\n            \"performance\": 0.210648\n        },\n        {\n            \"valuation_date\": \"2022-01-06\",\n            \"performance\": 0.2168\n        },\n        {\n            \"valuation_date\": \"2022-01-05\",\n            \"performance\": 0.147545\n        },\n        {\n            \"valuation_date\": \"2022-01-04\",\n            \"performance\": 0.228148\n        },\n        {\n            \"valuation_date\": \"2022-01-03\",\n            \"performance\": 0.247306\n        },\n        {\n            \"valuation_date\": \"2021-12-31\",\n            \"performance\": 0.131139\n        },\n        {\n            \"valuation_date\": \"2021-12-30\",\n            \"performance\": 0.131139\n        },\n        {\n            \"valuation_date\": \"2021-12-29\",\n            \"performance\": 0.140845\n        },\n        {\n            \"valuation_date\": \"2021-12-28\",\n            \"performance\": 0.138653\n        },\n        {\n            \"valuation_date\": \"2021-12-27\",\n            \"performance\": 0.307175\n        },\n        {\n            \"valuation_date\": \"2021-12-24\",\n            \"performance\": 0.464276\n        },\n        {\n            \"valuation_date\": \"2021-12-23\",\n            \"performance\": 0.464276\n        },\n        {\n            \"valuation_date\": \"2021-12-22\",\n            \"performance\": 0.505842\n        },\n        {\n            \"valuation_date\": \"2021-12-21\",\n            \"performance\": 0.504457\n        },\n        {\n            \"valuation_date\": \"2021-12-20\",\n            \"performance\": 0.395424\n        },\n        {\n            \"valuation_date\": \"2021-12-17\",\n            \"performance\": 0.421309\n        },\n        {\n            \"valuation_date\": \"2021-12-16\",\n            \"performance\": 0.507694\n        },\n        {\n            \"valuation_date\": \"2021-12-15\",\n            \"performance\": 0.579051\n        },\n        {\n            \"valuation_date\": \"2021-12-14\",\n            \"performance\": 0.573649\n        },\n        {\n            \"valuation_date\": \"2021-12-13\",\n            \"performance\": 0.536737\n        },\n        {\n            \"valuation_date\": \"2021-12-10\",\n            \"performance\": 0.605266\n        },\n        {\n            \"valuation_date\": \"2021-12-09\",\n            \"performance\": 0.693253\n        },\n        {\n            \"valuation_date\": \"2021-12-08\",\n            \"performance\": 0.579843\n        },\n        {\n            \"valuation_date\": \"2021-12-07\",\n            \"performance\": 0.516046\n        },\n        {\n            \"valuation_date\": \"2021-12-06\",\n            \"performance\": 0.612485\n        },\n        {\n            \"valuation_date\": \"2021-12-03\",\n            \"performance\": 0.626634\n        },\n        {\n            \"valuation_date\": \"2021-12-02\",\n            \"performance\": 0.621752\n        },\n        {\n            \"valuation_date\": \"2021-12-01\",\n            \"performance\": 0.567333\n        },\n        {\n            \"valuation_date\": \"2021-11-30\",\n            \"performance\": 0.636545\n        },\n        {\n            \"valuation_date\": \"2021-11-29\",\n            \"performance\": 0.677717\n        },\n        {\n            \"valuation_date\": \"2021-11-26\",\n            \"performance\": 0.746118\n        },\n        {\n            \"valuation_date\": \"2021-11-25\",\n            \"performance\": 0.44607\n        },\n        {\n            \"valuation_date\": \"2021-11-24\",\n            \"performance\": 0.401858\n        },\n        {\n            \"valuation_date\": \"2021-11-23\",\n            \"performance\": 0.35487\n        },\n        {\n            \"valuation_date\": \"2021-11-22\",\n            \"performance\": 0.360872\n        },\n        {\n            \"valuation_date\": \"2021-11-19\",\n            \"performance\": 0.337422\n        },\n        {\n            \"valuation_date\": \"2021-11-18\",\n            \"performance\": 0.387958\n        },\n        {\n            \"valuation_date\": \"2021-11-17\",\n            \"performance\": 0.221262\n        },\n        {\n            \"valuation_date\": \"2021-11-16\",\n            \"performance\": 0.074618\n        },\n        {\n            \"valuation_date\": \"2021-11-15\",\n            \"performance\": -0.153454\n        },\n        {\n            \"valuation_date\": \"2021-11-12\",\n            \"performance\": -0.04681\n        },\n        {\n            \"valuation_date\": \"2021-11-11\",\n            \"performance\": 0.197169\n        },\n        {\n            \"valuation_date\": \"2021-11-10\",\n            \"performance\": 0.211501\n        },\n        {\n            \"valuation_date\": \"2021-11-09\",\n            \"performance\": 0.211303\n        },\n        {\n            \"valuation_date\": \"2021-11-08\",\n            \"performance\": 0.063467\n        },\n        {\n            \"valuation_date\": \"2021-11-05\",\n            \"performance\": -0.011104\n        },\n        {\n            \"valuation_date\": \"2021-11-04\",\n            \"performance\": -0.133152\n        },\n        {\n            \"valuation_date\": \"2021-11-03\",\n            \"performance\": -0.2219\n        },\n        {\n            \"valuation_date\": \"2021-11-02\",\n            \"performance\": -0.057349\n        },\n        {\n            \"valuation_date\": \"2021-11-01\",\n            \"performance\": -0.000085\n        },\n        {\n            \"valuation_date\": \"2021-10-29\",\n            \"performance\": 0\n        }\n    ]\n}"
 								}
 							]
 						},
@@ -19562,6 +21091,96 @@
 									],
 									"cookie": [],
 									"body": "{\n    \"count\": 29,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"valuation_date\": \"2021-02-10\",\n            \"percentage\": 0\n        },\n        {\n            \"valuation_date\": \"2021-02-11\",\n            \"percentage\": 1580.426757\n        },\n        {\n            \"valuation_date\": \"2021-02-12\",\n            \"percentage\": 338.090067\n        },\n        {\n            \"valuation_date\": \"2021-02-15\",\n            \"percentage\": 86.785697\n        },\n        {\n            \"valuation_date\": \"2021-02-16\",\n            \"percentage\": 85.27191\n        },\n        {\n            \"valuation_date\": \"2021-02-17\",\n            \"percentage\": 39.124619\n        },\n        {\n            \"valuation_date\": \"2021-02-18\",\n            \"percentage\": 48.363033\n        },\n        {\n            \"valuation_date\": \"2021-02-19\",\n            \"percentage\": 53.137367\n        },\n        {\n            \"valuation_date\": \"2021-02-22\",\n            \"percentage\": 100.458933\n        },\n        {\n            \"valuation_date\": \"2021-02-23\",\n            \"percentage\": 45.952977\n        },\n        {\n            \"valuation_date\": \"2021-02-24\",\n            \"percentage\": -6.404797\n        },\n        {\n            \"valuation_date\": \"2021-02-25\",\n            \"percentage\": 4.844293\n        },\n        {\n            \"valuation_date\": \"2021-02-26\",\n            \"percentage\": -3.479442\n        },\n        {\n            \"valuation_date\": \"2021-03-01\",\n            \"percentage\": 5.276623\n        },\n        {\n            \"valuation_date\": \"2021-03-02\",\n            \"percentage\": 2.189503\n        },\n        {\n            \"valuation_date\": \"2021-03-03\",\n            \"percentage\": -0.981888\n        },\n        {\n            \"valuation_date\": \"2021-03-04\",\n            \"percentage\": 0.169783\n        },\n        {\n            \"valuation_date\": \"2021-03-05\",\n            \"percentage\": 14.667949\n        },\n        {\n            \"valuation_date\": \"2021-03-08\",\n            \"percentage\": 15.140307\n        },\n        {\n            \"valuation_date\": \"2021-03-09\",\n            \"percentage\": 2.779353\n        },\n        {\n            \"valuation_date\": \"2021-03-10\",\n            \"percentage\": 5.106672\n        },\n        {\n            \"valuation_date\": \"2021-03-11\",\n            \"percentage\": -18.298902\n        },\n        {\n            \"valuation_date\": \"2021-03-12\",\n            \"percentage\": -15.574668\n        },\n        {\n            \"valuation_date\": \"2021-03-15\",\n            \"percentage\": -3.082202\n        },\n        {\n            \"valuation_date\": \"2021-03-16\",\n            \"percentage\": -19.385972\n        },\n        {\n            \"valuation_date\": \"2021-03-17\",\n            \"percentage\": -16.178898\n        },\n        {\n            \"valuation_date\": \"2021-03-18\",\n            \"percentage\": -0.862925\n        },\n        {\n            \"valuation_date\": \"2021-03-19\",\n            \"percentage\": -3.860715\n        },\n        {\n            \"valuation_date\": \"2021-03-22\",\n            \"percentage\": -3.77943\n        }\n    ]\n}"
+								},
+								{
+									"name": "ok, ordering valuation_date",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "{{auth_token}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{host}}:{{port}}/api/v2/portfolios/{{portfolio_uuid}}/performance/mwrr/?ordering=-valuation_date",
+											"host": [
+												"{{host}}"
+											],
+											"port": "{{port}}",
+											"path": [
+												"api",
+												"v2",
+												"portfolios",
+												"{{portfolio_uuid}}",
+												"performance",
+												"mwrr",
+												""
+											],
+											"query": [
+												{
+													"key": "ordering",
+													"value": "-valuation_date"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Date",
+											"value": "Tue, 08 Mar 2022 08:33:24 GMT"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Content-Length",
+											"value": "5126"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Server",
+											"value": "nginx"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept, Origin, Accept-Language, Cookie"
+										},
+										{
+											"key": "Allow",
+											"value": "GET"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "DENY"
+										},
+										{
+											"key": "Content-Language",
+											"value": "en-gb"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "Referrer-Policy",
+											"value": "same-origin"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=31536000; includeSubDomains"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"count\": 92,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"valuation_date\": \"2022-03-07\",\n            \"performance\": -0.43234\n        },\n        {\n            \"valuation_date\": \"2022-03-04\",\n            \"performance\": -0.391507\n        },\n        {\n            \"valuation_date\": \"2022-03-03\",\n            \"performance\": -0.618352\n        },\n        {\n            \"valuation_date\": \"2022-03-02\",\n            \"performance\": -0.242872\n        },\n        {\n            \"valuation_date\": \"2022-03-01\",\n            \"performance\": -0.220828\n        },\n        {\n            \"valuation_date\": \"2022-02-28\",\n            \"performance\": -0.420106\n        },\n        {\n            \"valuation_date\": \"2022-02-25\",\n            \"performance\": -0.668198\n        },\n        {\n            \"valuation_date\": \"2022-02-24\",\n            \"performance\": -0.414206\n        },\n        {\n            \"valuation_date\": \"2022-02-23\",\n            \"performance\": -0.884967\n        },\n        {\n            \"valuation_date\": \"2022-02-22\",\n            \"performance\": -1.058269\n        },\n        {\n            \"valuation_date\": \"2022-02-21\",\n            \"performance\": -1.075541\n        },\n        {\n            \"valuation_date\": \"2022-02-18\",\n            \"performance\": -1.093516\n        },\n        {\n            \"valuation_date\": \"2022-02-17\",\n            \"performance\": -0.828873\n        },\n        {\n            \"valuation_date\": \"2022-02-16\",\n            \"performance\": -0.375303\n        },\n        {\n            \"valuation_date\": \"2022-02-15\",\n            \"performance\": 0.187127\n        },\n        {\n            \"valuation_date\": \"2022-02-14\",\n            \"performance\": -0.097462\n        },\n        {\n            \"valuation_date\": \"2022-02-11\",\n            \"performance\": 0.574025\n        },\n        {\n            \"valuation_date\": \"2022-02-10\",\n            \"performance\": 0.810623\n        },\n        {\n            \"valuation_date\": \"2022-02-09\",\n            \"performance\": 0.640315\n        },\n        {\n            \"valuation_date\": \"2022-02-08\",\n            \"performance\": 0.577318\n        },\n        {\n            \"valuation_date\": \"2022-02-07\",\n            \"performance\": 0.636371\n        },\n        {\n            \"valuation_date\": \"2022-02-04\",\n            \"performance\": 0.112442\n        },\n        {\n            \"valuation_date\": \"2022-02-03\",\n            \"performance\": 0.393132\n        },\n        {\n            \"valuation_date\": \"2022-02-02\",\n            \"performance\": 0.776886\n        },\n        {\n            \"valuation_date\": \"2022-02-01\",\n            \"performance\": 0.899027\n        },\n        {\n            \"valuation_date\": \"2022-01-31\",\n            \"performance\": 1.292707\n        },\n        {\n            \"valuation_date\": \"2022-01-28\",\n            \"performance\": 1.902922\n        },\n        {\n            \"valuation_date\": \"2022-01-27\",\n            \"performance\": 2.223208\n        },\n        {\n            \"valuation_date\": \"2022-01-26\",\n            \"performance\": 2.349032\n        },\n        {\n            \"valuation_date\": \"2022-01-25\",\n            \"performance\": 2.473897\n        },\n        {\n            \"valuation_date\": \"2022-01-24\",\n            \"performance\": 2.164736\n        },\n        {\n            \"valuation_date\": \"2022-01-21\",\n            \"performance\": 1.924738\n        },\n        {\n            \"valuation_date\": \"2022-01-20\",\n            \"performance\": 1.673837\n        },\n        {\n            \"valuation_date\": \"2022-01-19\",\n            \"performance\": 2.352937\n        },\n        {\n            \"valuation_date\": \"2022-01-18\",\n            \"performance\": 1.647713\n        },\n        {\n            \"valuation_date\": \"2022-01-17\",\n            \"performance\": 2.761976\n        },\n        {\n            \"valuation_date\": \"2022-01-14\",\n            \"performance\": 2.586911\n        },\n        {\n            \"valuation_date\": \"2022-01-13\",\n            \"performance\": 2.549725\n        },\n        {\n            \"valuation_date\": \"2022-01-12\",\n            \"performance\": 2.462953\n        },\n        {\n            \"valuation_date\": \"2022-01-11\",\n            \"performance\": 2.173469\n        },\n        {\n            \"valuation_date\": \"2022-01-10\",\n            \"performance\": 1.326141\n        },\n        {\n            \"valuation_date\": \"2022-01-07\",\n            \"performance\": 0.385989\n        },\n        {\n            \"valuation_date\": \"2022-01-06\",\n            \"performance\": 0.432593\n        },\n        {\n            \"valuation_date\": \"2022-01-05\",\n            \"performance\": -0.0146\n        },\n        {\n            \"valuation_date\": \"2022-01-04\",\n            \"performance\": 0.524576\n        },\n        {\n            \"valuation_date\": \"2022-01-03\",\n            \"performance\": 0.665371\n        },\n        {\n            \"valuation_date\": \"2021-12-31\",\n            \"performance\": -0.134202\n        },\n        {\n            \"valuation_date\": \"2021-12-30\",\n            \"performance\": -0.136907\n        },\n        {\n            \"valuation_date\": \"2021-12-29\",\n            \"performance\": -0.066959\n        },\n        {\n            \"valuation_date\": \"2021-12-28\",\n            \"performance\": -0.085148\n        },\n        {\n            \"valuation_date\": \"2021-12-27\",\n            \"performance\": 1.238231\n        },\n        {\n            \"valuation_date\": \"2021-12-24\",\n            \"performance\": 2.444578\n        },\n        {\n            \"valuation_date\": \"2021-12-23\",\n            \"performance\": 2.493739\n        },\n        {\n            \"valuation_date\": \"2021-12-22\",\n            \"performance\": 2.859187\n        },\n        {\n            \"valuation_date\": \"2021-12-21\",\n            \"performance\": 2.908479\n        },\n        {\n            \"valuation_date\": \"2021-12-20\",\n            \"performance\": 2.112668\n        },\n        {\n            \"valuation_date\": \"2021-12-17\",\n            \"performance\": 2.474448\n        },\n        {\n            \"valuation_date\": \"2021-12-16\",\n            \"performance\": 3.277409\n        },\n        {\n            \"valuation_date\": \"2021-12-15\",\n            \"performance\": 3.990322\n        },\n        {\n            \"valuation_date\": \"2021-12-14\",\n            \"performance\": 4.039442\n        },\n        {\n            \"valuation_date\": \"2021-12-13\",\n            \"performance\": 3.796328\n        },\n        {\n            \"valuation_date\": \"2021-12-10\",\n            \"performance\": 4.803109\n        },\n        {\n            \"valuation_date\": \"2021-12-09\",\n            \"performance\": 5.863696\n        },\n        {\n            \"valuation_date\": \"2021-12-08\",\n            \"performance\": 4.807791\n        },\n        {\n            \"valuation_date\": \"2021-12-07\",\n            \"performance\": 4.2459\n        },\n        {\n            \"valuation_date\": \"2021-12-06\",\n            \"performance\": 5.477308\n        },\n        {\n            \"valuation_date\": \"2021-12-03\",\n            \"performance\": 6.21422\n        },\n        {\n            \"valuation_date\": \"2021-12-02\",\n            \"performance\": 6.368404\n        },\n        {\n            \"valuation_date\": \"2021-12-01\",\n            \"performance\": 5.860435\n        },\n        {\n            \"valuation_date\": \"2021-11-30\",\n            \"performance\": 7.059475\n        },\n        {\n            \"valuation_date\": \"2021-11-29\",\n            \"performance\": 7.946718\n        },\n        {\n            \"valuation_date\": \"2021-11-26\",\n            \"performance\": 10.175104\n        },\n        {\n            \"valuation_date\": \"2021-11-25\",\n            \"performance\": 6.201491\n        },\n        {\n            \"valuation_date\": \"2021-11-24\",\n            \"performance\": 5.791674\n        },\n        {\n            \"valuation_date\": \"2021-11-23\",\n            \"performance\": 5.308011\n        },\n        {\n            \"valuation_date\": \"2021-11-22\",\n            \"performance\": 5.631225\n        },\n        {\n            \"valuation_date\": \"2021-11-19\",\n            \"performance\": 6.029634\n        },\n        {\n            \"valuation_date\": \"2021-11-18\",\n            \"performance\": 7.322201\n        },\n        {\n            \"valuation_date\": \"2021-11-17\",\n            \"performance\": 4.337291\n        },\n        {\n            \"valuation_date\": \"2021-11-16\",\n            \"performance\": 1.52402\n        },\n        {\n            \"valuation_date\": \"2021-11-15\",\n            \"performance\": -3.243511\n        },\n        {\n            \"valuation_date\": \"2021-11-12\",\n            \"performance\": -1.21327\n        },\n        {\n            \"valuation_date\": \"2021-11-11\",\n            \"performance\": 5.686207\n        },\n        {\n            \"valuation_date\": \"2021-11-10\",\n            \"performance\": 6.637316\n        },\n        {\n            \"valuation_date\": \"2021-11-09\",\n            \"performance\": 7.255095\n        },\n        {\n            \"valuation_date\": \"2021-11-08\",\n            \"performance\": 2.342797\n        },\n        {\n            \"valuation_date\": \"2021-11-05\",\n            \"performance\": -0.577354\n        },\n        {\n            \"valuation_date\": \"2021-11-04\",\n            \"performance\": -7.785683\n        },\n        {\n            \"valuation_date\": \"2021-11-03\",\n            \"performance\": -14.97008\n        },\n        {\n            \"valuation_date\": \"2021-11-02\",\n            \"performance\": -5.099866\n        },\n        {\n            \"valuation_date\": \"2021-11-01\",\n            \"performance\": -0.01022\n        },\n        {\n            \"valuation_date\": \"2021-10-29\",\n            \"performance\": 0\n        }\n    ]\n}"
 								}
 							]
 						},
@@ -20378,6 +21997,186 @@
 							],
 							"cookie": [],
 							"body": "{\n    \"count\": 6,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"bc005af0-41b2-4669-89f4-9ea2cae5802f\",\n            \"name\": \"Mock Mock Portfolio 0\",\n            \"portfolio_type\": \"3A\",\n            \"risk_level\": 3,\n            \"time_horizon\": 30,\n            \"status\": \"ACTIVE\",\n            \"balance\": 11908.982244,\n            \"invested\": 12000,\n            \"currency\": \"CHF\",\n            \"created\": \"2021-03-23T10:05:35.335314Z\",\n            \"advisor\": \"ets\",\n            \"advice_engine\": \"ets\"\n        },\n        {\n            \"uuid\": \"838e6b56-1887-46be-a2a0-f708d19d5994\",\n            \"name\": \"Mock Mock Portfolio 0\",\n            \"portfolio_type\": \"3A\",\n            \"risk_level\": 4,\n            \"time_horizon\": 30,\n            \"status\": \"ACTIVE\",\n            \"balance\": 11955.335928,\n            \"invested\": 12000,\n            \"currency\": \"CHF\",\n            \"created\": \"2021-03-23T10:03:54.342895Z\",\n            \"advisor\": \"ets\",\n            \"advice_engine\": \"ets\"\n        },\n        {\n            \"uuid\": \"ed053aa1-7580-40bf-841d-c95044479f8b\",\n            \"name\": \"Mock Mock Portfolio 0\",\n            \"portfolio_type\": \"3A\",\n            \"risk_level\": 2,\n            \"time_horizon\": 30,\n            \"status\": \"ACTIVE\",\n            \"balance\": 11972.148726,\n            \"invested\": 12000,\n            \"currency\": \"CHF\",\n            \"created\": \"2021-03-23T10:03:40.382881Z\",\n            \"advisor\": \"ets\",\n            \"advice_engine\": \"ets\"\n        },\n        {\n            \"uuid\": \"ebeeda86-6db0-4aee-9dd4-3ef3880691dc\",\n            \"name\": \"Mock Portfolio 2\",\n            \"portfolio_type\": \"3A\",\n            \"risk_level\": 2,\n            \"time_horizon\": 30,\n            \"status\": \"PENDING\",\n            \"balance\": 0,\n            \"invested\": 0,\n            \"currency\": \"CHF\",\n            \"created\": \"2021-03-23T10:03:39.259389Z\",\n            \"advisor\": \"ets\",\n            \"advice_engine\": \"ets\"\n        },\n        {\n            \"uuid\": \"473d2f6d-3d9b-4cf8-9d65-737478c47db0\",\n            \"name\": \"Mock Portfolio 1\",\n            \"portfolio_type\": \"3A\",\n            \"risk_level\": 2,\n            \"time_horizon\": 30,\n            \"status\": \"PENDING\",\n            \"balance\": 0,\n            \"invested\": 0,\n            \"currency\": \"CHF\",\n            \"created\": \"2021-03-23T10:03:39.203250Z\",\n            \"advisor\": \"ets\",\n            \"advice_engine\": \"ets\"\n        },\n        {\n            \"uuid\": \"fadd201b-c200-4731-8e32-aebac987f293\",\n            \"name\": \"Mock Portfolio 0\",\n            \"portfolio_type\": \"3A\",\n            \"risk_level\": 2,\n            \"time_horizon\": 30,\n            \"status\": \"PENDING\",\n            \"balance\": 0,\n            \"invested\": 0,\n            \"currency\": \"CHF\",\n            \"created\": \"2021-03-23T10:03:39.148843Z\",\n            \"advisor\": \"ets\",\n            \"advice_engine\": \"ets\"\n        }\n    ]\n}"
+						},
+						{
+							"name": "ok, ordering by risk_level",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{auth_token}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{host}}:{{port}}/api/v2/portfolios/?ordering=-risk_level",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"api",
+										"v2",
+										"portfolios",
+										""
+									],
+									"query": [
+										{
+											"key": "ordering",
+											"value": "-risk_level"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Date",
+									"value": "Tue, 08 Mar 2022 08:51:32 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Content-Length",
+									"value": "1034"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Server",
+									"value": "nginx"
+								},
+								{
+									"key": "Vary",
+									"value": "Accept, Origin, Accept-Language, Cookie"
+								},
+								{
+									"key": "Allow",
+									"value": "GET, POST"
+								},
+								{
+									"key": "X-Frame-Options",
+									"value": "DENY"
+								},
+								{
+									"key": "Content-Language",
+									"value": "en-gb"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "Referrer-Policy",
+									"value": "same-origin"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=31536000; includeSubDomains"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"count\": 3,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"b40e9de1-dfbe-4a34-b6e2-b4daff194a66\",\n            \"client\": \"c2860389-fdc4-4a68-b7bd-70c5d5ac1698\",\n            \"name\": \"My safety net\",\n            \"portfolio_type\": \"GIA\",\n            \"risk_level\": 5,\n            \"time_horizon\": 30,\n            \"status\": \"ACTIVE\",\n            \"balance\": 18518.4198,\n            \"invested\": 18000,\n            \"currency\": \"EUR\",\n            \"created\": \"2022-03-07T15:33:40.533733Z\",\n            \"advice_engine\": \"model_portfolio\"\n        },\n        {\n            \"uuid\": \"99a701f3-9bfb-4485-a438-89bb219f9e83\",\n            \"client\": \"5e48cf50-865d-4017-9e00-1acf8d42caec\",\n            \"name\": \"Low risk portfolio\",\n            \"portfolio_type\": \"GIA\",\n            \"risk_level\": 3,\n            \"time_horizon\": 30,\n            \"status\": \"ACTIVE\",\n            \"balance\": 18242.2273,\n            \"invested\": 18000,\n            \"currency\": \"EUR\",\n            \"created\": \"2022-03-07T15:36:29.030139Z\",\n            \"advice_engine\": \"model_portfolio\"\n        },\n        {\n            \"uuid\": \"9d157608-95d3-45be-9888-a0e794cdbee0\",\n            \"client\": \"e9f39707-f0f3-4a77-a119-4826354e9e5a\",\n            \"name\": \"High risk portfolio\",\n            \"portfolio_type\": \"GIA\",\n            \"risk_level\": 2,\n            \"time_horizon\": 30,\n            \"status\": \"ACTIVE\",\n            \"balance\": 18798.8839,\n            \"invested\": 18000,\n            \"currency\": \"EUR\",\n            \"created\": \"2022-03-07T15:39:20.549658Z\",\n            \"advice_engine\": \"model_portfolio\"\n        }\n    ]\n}"
+						},
+						{
+							"name": "ok, filter by asset isin",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{auth_token}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{host}}:{{port}}/api/v2/portfolios/?asset_isin=DE0005557508",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"api",
+										"v2",
+										"portfolios",
+										""
+									],
+									"query": [
+										{
+											"key": "asset_isin",
+											"value": "DE0005557508"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Date",
+									"value": "Tue, 08 Mar 2022 09:02:10 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Content-Length",
+									"value": "381"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								},
+								{
+									"key": "Server",
+									"value": "nginx"
+								},
+								{
+									"key": "Vary",
+									"value": "Accept, Origin, Accept-Language, Cookie"
+								},
+								{
+									"key": "Allow",
+									"value": "GET, POST"
+								},
+								{
+									"key": "X-Frame-Options",
+									"value": "DENY"
+								},
+								{
+									"key": "Content-Language",
+									"value": "en-gb"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "Referrer-Policy",
+									"value": "same-origin"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=31536000; includeSubDomains"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"count\": 1,\n    \"next\": null,\n    \"previous\": null,\n    \"results\": [\n        {\n            \"uuid\": \"9d157608-95d3-45be-9888-a0e794cdbee0\",\n            \"client\": \"e9f39707-f0f3-4a77-a119-4826354e9e5a\",\n            \"name\": \"High risk portfolio\",\n            \"portfolio_type\": \"GIA\",\n            \"risk_level\": 2,\n            \"time_horizon\": 30,\n            \"status\": \"ACTIVE\",\n            \"balance\": 18798.8839,\n            \"invested\": 18000,\n            \"currency\": \"EUR\",\n            \"created\": \"2022-03-07T15:39:20.549658Z\",\n            \"advice_engine\": \"model_portfolio\"\n        }\n    ]\n}"
 						}
 					]
 				},


### PR DESCRIPTION
- Order by valuation_date in allocations NP-8854 
- Order param valuation_date in performance NP-8857
- Order param valuation_date in performance mwrr NP-8858
- Order param name in asset list NP-8859
- Order param year in asset performance NP-8860
- Order param created & completed in orders NP-8861
- Order by date fields in account statements NP-8863
- Order by date fields in tax reports NP-8864
- Order by created in documents NP-8865
- Order by created and risk_level in Portfolios NP-8868
- Order by dates in invoices and charges NP-8869